### PR TITLE
add missing TXT entry for terraform.io in data_dns_txt_record_set_test

### DIFF
--- a/dns/data_dns_txt_record_set_test.go
+++ b/dns/data_dns_txt_record_set_test.go
@@ -25,6 +25,7 @@ func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
 				"google-site-verification=LQZvxDzrGE-ZLudDpkpj-gcXN-5yF7Z6C-4Rljs3I_Q",
 				"google-site-verification=8d7FpfB8aOEYAIkoaVKxg7Ibj438CEypjZTH424Pews",
 				"google-site-verification=y974ACvos30pN7_OBgEZb_byZV8qYtK0G6WZfE7OX8s",
+				"keybase-site-verification=5HKqMvJnTWpe8W-Aa8r0y3wuy1bhQ6LwcjaxKE9BOQU",
 			},
 			"terraform.io",
 		},


### PR DESCRIPTION
The test for `data_dns_txt_record_set_test` includes a check of the TXT records for the real-world terraform.io domain. Previously, there were three google-site-verification entries for terraform.io that are included in the test. However, a new entry for keybase-site-verification appears to have been added to terraform.io that is now causing this test to fail. 

This PR adds the missing TXT entry. 

It might be a good idea to create some permanent DNS entries intended for testing this functionality (perhaps in a subdomain of terraform.io?) so that it does not break again in the future. 

