### PR TITLE
docs/provider: Clarify and linkify provider summary

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # DNS Provider
 
-The DNS provider supports DNS updates (RFC 2136). Additionally, the provider can be configured with secret key based transaction authentication (RFC 2845) or can use GSS-TSIG (RFC 3645).
+The DNS provider supports resources that perform DNS updates ([RFC 2136](https://datatracker.ietf.org/doc/html/rfc2136)) and data sources for reading DNS information. The provider can be configured with secret key based transaction authentication ([RFC 2845](https://datatracker.ietf.org/doc/html/rfc2845)) or GSS-TSIG ([RFC 3645](https://datatracker.ietf.org/doc/html/rfc3645)).
 
-Use the navigation to the left to read about the available resources.
+Use the navigation to the left to read about the available resources and data sources.
 
 ## Example Usage
 


### PR DESCRIPTION
When viewing the page, it can be helpful to be linked directly to the IETF RFC pages.