### PR TITLE
tests/provider: Support macOS in acceptance testing and document prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,54 @@ $ $GOPATH/bin/terraform-provider-dns
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
+In order to run unit testing for the provider:
 
 ```sh
 $ make test
 ```
 
-In order to run acceptance tests, excluding ones requiring a `DNS_UPDATE_SERVER` run `make testacc`.
-
-To run the full suite of acceptance tests run `./internal/provider/acceptance.sh`. You will need docker installed. 
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
+In order to run acceptance tests, excluding ones requiring a `DNS_UPDATE_SERVER`:
 
 ```sh
 $ make testacc
+```
+
+To run the full suite of acceptance tests:
+
+```sh
+$ ./internal/provider/acceptance.sh
+```
+
+Which has the following prerequisites:
+
+- [Docker](https://www.docker.com/)
+- [Go](https://golang.org/)
+- [Kerberos Clients](https://web.mit.edu/kerberos/dist/) (e.g. `kinit`)
+- [Make](https://www.gnu.org/software/make/)
+- [Terraform CLI](https://terraform.io/)
+- `/etc/hosts` entry (or equivalent): `127.0.0.1 ns.example.com`
+
+### macOS Setup
+
+- [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
+- [Go](https://golang.org/dl/) or with Homebrew: `brew install go`
+- [Terraform CLI](https://www.terraform.io/downloads.html) or with Homebrew: `brew install hashicorp/tap/terraform`
+
+```shell
+echo "127.0.0.1 ns.example.com" | sudo tee -a /etc/hosts
+```
+
+### Ubuntu Setup
+
+- [Docker Engine](https://docs.docker.com/engine/install/ubuntu/)
+- [Go](https://github.com/golang/go/wiki/Ubuntu)
+- [Terraform CLI](https://www.terraform.io/docs/cli/install/apt.html)
+
+```shell
+echo "127.0.0.1 ns.example.com" | sudo tee -a /etc/hosts
+sudo apt-get install krb5-user make
+# If prompted for Kerberos configuration:
+# Default Realm: EXAMPLE.COM
+# Server: ns.example.com
+# Administrative Server: ns.example.com
 ```

--- a/internal/provider/acceptance.sh
+++ b/internal/provider/acceptance.sh
@@ -12,12 +12,19 @@ failed() {
 	exit 1
 }
 
+command -v docker >/dev/null 2>&1 || { echo >&2 "docker command not installed or in PATH"; exit 1; }
+command -v go >/dev/null 2>&1 || { echo >&2 "go command not installed or in PATH"; exit 1; }
+command -v kinit >/dev/null 2>&1 || { echo >&2 "kinit command not installed or in PATH"; exit 1; }
+command -v make >/dev/null 2>&1 || { echo >&2 "make command not installed or in PATH"; exit 1; }
+command -v terraform >/dev/null 2>&1 || test -n "${TF_ACC_TERRAFORM_PATH:-}" || { echo >&2 "terraform command not installed or in PATH, TF_ACC_TERRAFORM_PATH not set"; exit 1; }
+grep -q "ns.example.com" /etc/hosts || echo >&2 "127.0.0.1 ns.example.com not found in /etc/hosts, ensure this mapping is handled in DNS resolution configuration"
+
 docker buildx build --target kdc --tag kdc internal/provider/testdata/
 docker buildx build --target ns --tag ns internal/provider/testdata/
 docker buildx build --target keytab --output type=local,dest=internal/provider/testdata/ internal/provider/testdata/
 
 export DNS_UPDATE_SERVER=127.0.0.1
-export DNS_UPDATE_PORT=53
+export DNS_UPDATE_PORT=15353
 
 # Run with no authentication
 
@@ -25,8 +32,8 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.none:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
 GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker
@@ -37,8 +44,8 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.md5:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
 DNS_UPDATE_KEYNAME="tsig.example.com." DNS_UPDATE_KEYALGORITHM="hmac-md5" DNS_UPDATE_KEYSECRET="mX9XKfw/RXBj5ZnZKMy4Nw==" GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker
@@ -49,8 +56,8 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.sha256:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
 DNS_UPDATE_KEYNAME="tsig.example.com." DNS_UPDATE_KEYALGORITHM="hmac-sha256" DNS_UPDATE_KEYSECRET="UHeh4Iv/DVmPhi6LqCPDs6PixnyjLH4fjGESBjYnOyE=" GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker
@@ -64,8 +71,8 @@ export DNS_UPDATE_SERVER="ns.example.com"
 docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
-	-p 127.0.0.1:88:88 \
-	-p 127.0.0.1:88:88/udp \
+	-p 127.0.0.1:18888:88 \
+	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
@@ -73,8 +80,8 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
 DNS_UPDATE_USERNAME="test" DNS_UPDATE_PASSWORD="password" GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker
@@ -84,8 +91,8 @@ cleanup_docker
 docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
-	-p 127.0.0.1:88:88 \
-	-p 127.0.0.1:88:88/udp \
+	-p 127.0.0.1:18888:88 \
+	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
@@ -93,8 +100,8 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
 DNS_UPDATE_USERNAME="test" DNS_UPDATE_KEYTAB="${PWD}/internal/provider/testdata/test.keytab" GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker
@@ -104,8 +111,8 @@ cleanup_docker
 docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
-	-p 127.0.0.1:88:88 \
-	-p 127.0.0.1:88:88/udp \
+	-p 127.0.0.1:18888:88 \
+	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
@@ -113,9 +120,9 @@ docker run -d --tmpfs /tmp --tmpfs /run \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
-	-p 127.0.0.1:53:53 \
-	-p 127.0.0.1:53:53/udp \
+	-p 127.0.0.1:15353:53 \
+	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
-echo "password" | kinit test@EXAMPLE.COM
+echo "password" | kinit --password-file=STDIN test@EXAMPLE.COM || echo "password" | kinit test@EXAMPLE.COM
 GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker

--- a/internal/provider/testdata/krb5.conf
+++ b/internal/provider/testdata/krb5.conf
@@ -16,7 +16,7 @@
 
 [realms]
  EXAMPLE.COM = {
-  kdc = 127.0.0.1:88
+  kdc = 127.0.0.1:18888
   admin_server = 127.0.0.1:749
  }
 


### PR DESCRIPTION
Closes #140
Closes #143

Updates DNS and Kerberos port numbers to not collide with mac OS managed processes. Also, adds README documentation (and quick acceptance test script checks) for prerequisites.

Output from acceptance testing on mac OS 11.4:

```console
$ ./internal/provider/acceptance.sh
+ command -v docker
+ command -v go
+ command -v kinit
+ command -v make
+ command -v terraform
+ grep -q ns.example.com /etc/hosts
+ docker buildx build --target kdc --tag kdc internal/provider/testdata/
[+] Building 0.8s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                                              0.7s
 => [auth] centos/systemd:pull token for registry-1.docker.io                                                                                                                 0.0s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                                                  0.0s
 => [internal] load build context                                                                                                                                             0.0s
 => => transferring context: 87B                                                                                                                                              0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                                                  0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                                        0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                                           0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                                        0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                                         0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                                                       0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                                           0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                                                    0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                                               0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                                            0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                                             0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                                                  0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                                         0.0s
 => exporting to image                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                       0.0s
 => => writing image sha256:1485fc5e8b9b0b1a07ea49200ecf9c7f31ff69271bd9bf89b3f338fa6214a7aa                                                                                  0.0s
 => => naming to docker.io/library/kdc                                                                                                                                        0.0s
+ docker buildx build --target ns --tag ns internal/provider/testdata/
[+] Building 0.2s (25/25) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                                              0.1s
 => [internal] load build context                                                                                                                                             0.0s
 => => transferring context: 731B                                                                                                                                             0.0s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                                                  0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                                                  0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                                        0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                                           0.0s
 => CACHED [ns  5/10] RUN yum install -y bind bind-utils && yum clean all                                                                                                     0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                                        0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                                         0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                                                       0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                                           0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                                                    0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                                               0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                                            0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                                             0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                                                  0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                                         0.0s
 => CACHED [ns  6/10] COPY --from=kdc --chown=root:named /etc/named.keytab /etc/named.keytab                                                                                  0.0s
 => CACHED [ns  7/10] RUN chmod 640 /etc/named.keytab                                                                                                                         0.0s
 => CACHED [ns  8/10] RUN systemctl enable named.service                                                                                                                      0.0s
 => CACHED [ns  9/10] COPY --chown=named:named db.* /var/named/dynamic/                                                                                                       0.0s
 => CACHED [ns 10/10] RUN chmod 644 /var/named/dynamic/db.*                                                                                                                   0.0s
 => exporting to image                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                       0.0s
 => => writing image sha256:3d4c278b07f9cfc6b192af2b72f56bd7f0904d55b535280e94c83d2acb94de77                                                                                  0.0s
 => => naming to docker.io/library/ns                                                                                                                                         0.0s
+ docker buildx build --target keytab --output type=local,dest=internal/provider/testdata/ internal/provider/testdata/
[+] Building 0.2s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                                              0.1s
 => [internal] load build context                                                                                                                                             0.0s
 => => transferring context: 87B                                                                                                                                              0.0s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                                                  0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                                                  0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                                        0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                                           0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                                        0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                                         0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                                                       0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                                           0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                                                    0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                                               0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                                            0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                                             0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                                                  0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                                         0.0s
 => CACHED [keytab 1/1] COPY --from=kdc /etc/test.keytab /test.keytab                                                                                                         0.0s
 => exporting to client                                                                                                                                                       0.0s
 => => copying files 526B                                                                                                                                                     0.0s
+ export DNS_UPDATE_SERVER=127.0.0.1
+ DNS_UPDATE_SERVER=127.0.0.1
+ export DNS_UPDATE_PORT=15353
+ DNS_UPDATE_PORT=15353
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.none:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
edbe18f1e3beb32dbf14cb6fb639a655eb0e262b2bd610a79bc1f8531388c70c
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (1.74s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.46s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.46s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.53s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.50s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.45s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.49s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.55s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.59s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (6.89s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.13s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.77s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.18s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.66s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.35s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.91s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   55.020s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.md5:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
b7d256b1677b405c6fe90d0d020bae428da912598b8cc5084b6f71d5da47480a
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-md5
+ DNS_UPDATE_KEYSECRET=mX9XKfw/RXBj5ZnZKMy4Nw==
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (1.54s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.58s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.50s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.52s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.51s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.47s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.50s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.58s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.66s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (6.77s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.04s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.55s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.08s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.58s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.12s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.58s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   53.971s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.sha256:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
7ed9d2421548f0f847403955713ec3d81909989d0d062ed51b1baddc01f7d88a
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-sha256
+ DNS_UPDATE_KEYSECRET=UHeh4Iv/DVmPhi6LqCPDs6PixnyjLH4fjGESBjYnOyE=
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (1.41s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.41s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.42s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.46s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.50s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.42s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.45s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.55s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.55s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (6.69s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.04s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.57s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.04s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.56s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.10s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.60s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   53.105s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ export KRB5_CONFIG=/Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ KRB5_CONFIG=/Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ export DNS_UPDATE_REALM=EXAMPLE.COM
+ DNS_UPDATE_REALM=EXAMPLE.COM
+ export DNS_UPDATE_SERVER=ns.example.com
+ DNS_UPDATE_SERVER=ns.example.com
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
f16b2a04c8bfb826efcb4456ba82744a2bc9ba47d4e7b57e7cd2ef2e43949b9d
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
8b4a54b218c923d655b51253996d6fad50ce8911878761edfd1e77c0174fa25a
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_PASSWORD=password
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (1.55s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.43s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.42s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.47s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.49s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.42s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.48s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.52s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.84s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (7.05s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.26s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.93s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.27s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.89s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.32s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.95s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   55.746s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
5ffda3083ae3ce81bc7fcfbb2314755fc9f81af3697e1c4808abb8ca8da24f8b
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
6141505f5a288762b1635691d1c1c2045eb74f5917c3a22fcf40e3e3725ecb79
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_KEYTAB=/Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/test.keytab
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (1.72s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.43s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.45s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.46s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.47s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.43s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.51s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.60s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.76s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (7.32s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.19s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.76s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.21s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.82s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.23s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.75s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   55.539s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
5f0a834601bd28d8fb65aec2c80c222bc8255ffe5b4c25ede5e51288d9748c81
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
d944adf6329a1df5461809e90fec9aa67f853913c2f317d0d82f7388aa040711
+ echo password
+ kinit --password-file=STDIN test@EXAMPLE.COM
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (2.10s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.43s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.42s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.48s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.56s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.43s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.49s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (2.00s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (5.72s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (6.86s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (4.22s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (5.78s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (4.21s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (5.73s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (4.30s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (5.78s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   55.925s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
```

Output from acceptance testing on Ubuntu 20.04:

```console
$ ./internal/provider/acceptance.sh
+ command -v docker
+ command -v go
+ command -v kinit
+ command -v make
+ command -v terraform
+ grep -q ns.example.com /etc/hosts
+ docker buildx build --target kdc --tag kdc internal/provider/testdata/
[+] Building 0.2s (2/3)
[+] Building 0.4s (19/19) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                      0.3s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                          0.0s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 87B                                                                                                                      0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                          0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                   0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                 0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                               0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                   0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                            0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                       0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                    0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                     0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                          0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                 0.0s
 => exporting to image                                                                                                                                0.0s
 => => exporting layers                                                                                                                               0.0s
 => => writing image sha256:a8ec00fa18744ab95ce4d889e91c96b770d760a2f26444ae15e8c3a960f6b80b                                                          0.0s
 => => naming to docker.io/library/kdc                                                                                                                0.0s
+ docker buildx build --target ns --tag ns internal/provider/testdata/
[+] Building 0.1s (25/25) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                      0.1s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                          0.0s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 731B                                                                                                                     0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                          0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                   0.0s
 => CACHED [ns  5/10] RUN yum install -y bind bind-utils && yum clean all                                                                             0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                 0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                               0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                   0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                            0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                       0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                    0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                     0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                          0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                 0.0s
 => CACHED [ns  6/10] COPY --from=kdc --chown=root:named /etc/named.keytab /etc/named.keytab                                                          0.0s
 => CACHED [ns  7/10] RUN chmod 640 /etc/named.keytab                                                                                                 0.0s
 => CACHED [ns  8/10] RUN systemctl enable named.service                                                                                              0.0s
 => CACHED [ns  9/10] COPY --chown=named:named db.* /var/named/dynamic/                                                                               0.0s
 => CACHED [ns 10/10] RUN chmod 644 /var/named/dynamic/db.*                                                                                           0.0s
 => exporting to image                                                                                                                                0.0s
 => => exporting layers                                                                                                                               0.0s
 => => writing image sha256:a9fa4743283b429fcd3ba1fa3f89965477cb7a0b13c6bd854ce18870e4ca395b                                                          0.0s
 => => naming to docker.io/library/ns                                                                                                                 0.0s
+ docker buildx build --target keytab --output type=local,dest=internal/provider/testdata/ internal/provider/testdata/
[+] Building 0.2s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                                                      0.1s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 87B                                                                                                                      0.0s
 => [kdc  1/14] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b58                          0.0s
 => CACHED [kdc  2/14] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                                          0.0s
 => CACHED [kdc  3/14] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                                                0.0s
 => CACHED [kdc  4/14] RUN chmod 644 /etc/krb5.conf                                                                                                   0.0s
 => CACHED [kdc  5/14] RUN yum install -y krb5-server && yum clean all                                                                                0.0s
 => CACHED [kdc  6/14] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                                                 0.0s
 => CACHED [kdc  7/14] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                                               0.0s
 => CACHED [kdc  8/14] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                                   0.0s
 => CACHED [kdc  9/14] RUN systemctl enable krb5kdc.service kadmin.service                                                                            0.0s
 => CACHED [kdc 10/14] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)                       0.0s
 => CACHED [kdc 11/14] RUN kadmin.local addprinc -pw password test                                                                                    0.0s
 => CACHED [kdc 12/14] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                                     0.0s
 => CACHED [kdc 13/14] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                                          0.0s
 => CACHED [kdc 14/14] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                                                 0.0s
 => CACHED [keytab 1/1] COPY --from=kdc /etc/test.keytab /test.keytab                                                                                 0.0s
 => exporting to client                                                                                                                               0.0s
 => => copying files 526B                                                                                                                             0.0s
+ export DNS_UPDATE_SERVER=127.0.0.1
+ DNS_UPDATE_SERVER=127.0.0.1
+ export DNS_UPDATE_PORT=15353
+ DNS_UPDATE_PORT=15353
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.none:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
10008cc7b7847a1621667fb4ede6d43d75f92f6be19ba07760d5992972aa32cd
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.07s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.04s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.13s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.05s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.06s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.01s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.05s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.21s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (3.92s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (4.82s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.46s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.13s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (3.10s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.08s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.07s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.15s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   39.360s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.md5:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
22a895d8b5ef03f01af8022071cb5f22ab12e293169465ca314342be45ca50ea
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-md5
+ DNS_UPDATE_KEYSECRET=mX9XKfw/RXBj5ZnZKMy4Nw==
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.10s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.12s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.09s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.11s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.09s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.10s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.07s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.08s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (4.20s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (5.01s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.02s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.11s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (3.18s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.38s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.25s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.24s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   40.156s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.sha256:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
11ae3692543cab56f2f7c7258ba011513fdf3362d4e2480521780b19e1bb7a7f
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-sha256
+ DNS_UPDATE_KEYSECRET=UHeh4Iv/DVmPhi6LqCPDs6PixnyjLH4fjGESBjYnOyE=
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.17s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.18s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.21s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.19s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.11s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.16s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.13s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.13s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (4.27s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (5.02s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.05s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.07s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (2.98s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.09s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.03s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.02s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   39.813s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ export KRB5_CONFIG=/home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ KRB5_CONFIG=/home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ export DNS_UPDATE_REALM=EXAMPLE.COM
+ DNS_UPDATE_REALM=EXAMPLE.COM
+ export DNS_UPDATE_SERVER=ns.example.com
+ DNS_UPDATE_SERVER=ns.example.com
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
c135fe38bdbd1232fb19771de793c9aaaf75f25f86f982521718b47ce2284a8d
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
14b4829f75d4bb7ddca0c821d5e0ee2abf4bbae889b476ea087fbf077eb7ceaa
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_PASSWORD=password
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.09s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.04s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.11s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.07s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.10s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.05s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.10s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.04s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (4.29s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (5.53s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.20s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.35s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (3.16s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.33s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.20s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.27s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   40.956s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
9188361bbd2c2f48eefe9d6383b47ab139cc024457c94d4e5dd974d604746866
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
0845d43865838a676e29404897540c32fd43c6b91a27ab6a0fb8eaec7fe858f8
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_KEYTAB=/home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/test.keytab
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.08s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.06s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.13s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.08s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.08s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.07s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.11s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.07s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (4.27s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (5.13s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.03s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.29s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (3.14s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.16s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.01s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.63s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   40.354s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
6de458797085b1ffe8c2321a23ba20bf97ffc7550ae6c6c298c0e3d1cc58b427
+ docker run -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/localtime:/etc/localtime:ro -v /home/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
68454c0a0f77df1f25d432bdcb3526b150943d5bc722928234b8578acabfb219
+ kinit --password-file=STDIN test@EXAMPLE.COM
+ echo password
kinit: unrecognized option '--password-file=STDIN'
Usage: kinit [-V] [-l lifetime] [-s start_time]
        [-r renewable_life] [-f | -F | --forwardable | --noforwardable]
        [-p | -P | --proxiable | --noproxiable]
        -n [-a | -A | --addresses | --noaddresses]
        [--request-pac | --no-request-pac]
        [-C | --canonicalize]
        [-E | --enterprise]
        [-v] [-R] [-k [-i|-t keytab_file]] [-c cachename]
        [-S service_name] [-T ticket_armor_cache]
        [-X <attribute>[=<value>]] [principal]

    options:
        -V verbose
        -l lifetime
        -s start time
        -r renewable lifetime
        -f forwardable
        -F not forwardable
        -p proxiable
        -P not proxiable
        -n anonymous
        -a include addresses
        -A do not include addresses
        -v validate
        -R renew
        -C canonicalize
        -E client is enterprise principal name
        -k use keytab
        -i use default client keytab (with -k)
        -t filename of keytab to use
        -c Kerberos 5 cache name
        -S service
        -T armor credential cache
        -X <attribute>[=<value>]
+ echo password
+ kinit test@EXAMPLE.COM
Password for test@EXAMPLE.COM:
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
go package net: dynamic selection of DNS resolver
--- PASS: TestAccDataDnsARecordSet_Basic (1.12s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (1.09s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (1.06s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (1.08s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (1.04s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (1.07s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.06s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (1.11s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (4.25s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (5.09s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (3.07s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (4.23s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (3.11s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (4.17s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (3.13s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (4.14s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-dns/internal/provider   39.864s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
```