### PR TITLE
Documentation: Use latest Terraform syntax

### DIFF
--- a/website/docs/d/dns_a_record_set.html.markdown
+++ b/website/docs/d/dns_a_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_a_record_set" "google" {
 }
 
 output "google_addrs" {
-  value = "${join(",", data.dns_a_record_set.google.addrs)}"
+  value = join(",", data.dns_a_record_set.google.addrs)
 }
 ```
 

--- a/website/docs/d/dns_aaaa_record_set.html.markdown
+++ b/website/docs/d/dns_aaaa_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_aaaa_record_set" "google" {
 }
 
 output "google_addrs" {
-  value = "${join(",", data.dns_aaaa_record_set.google.addrs)}"
+  value = join(",", data.dns_aaaa_record_set.google.addrs)
 }
 ```
 

--- a/website/docs/d/dns_cname_record_set.html.markdown
+++ b/website/docs/d/dns_cname_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_cname_record_set" "hashicorp" {
 }
 
 output "hashi_cname" {
-  value = "${data.dns_cname_record_set.hashi.cname}"
+  value = data.dns_cname_record_set.hashi.cname
 }
 ```
 

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_mx_record_set" "mail" {
 }
 
 output "mailserver" {
-  value = "${data.dns_mx_record_set.mail.mx.0.exchange}"
+  value = data.dns_mx_record_set.mail.mx.0.exchange
 }
 ```
 

--- a/website/docs/d/dns_ns_record_set.html.markdown
+++ b/website/docs/d/dns_ns_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_ns_record_set" "google" {
 }
 
 output "google_nameservers" {
-  value = "${join(",", data.dns_ns_record_set.google.nameservers)}"
+  value = join(",", data.dns_ns_record_set.google.nameservers)
 }
 ```
 

--- a/website/docs/d/dns_ptr_record_set.html.markdown
+++ b/website/docs/d/dns_ptr_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_ptr_record_set" "hashicorp" {
 }
 
 output "hashi_ptr" {
-  value = "${data.dns_ptr_record_set.hashicorp.ptr}"
+  value = data.dns_ptr_record_set.hashicorp.ptr
 }
 ```
 

--- a/website/docs/d/dns_srv_record_set.html.markdown
+++ b/website/docs/d/dns_srv_record_set.html.markdown
@@ -18,7 +18,7 @@ data "dns_srv_record_set" "sip" {
 }
 
 output "sipserver" {
-  value = "${data.dns_srv_record_set.sip.srv.0.target}"
+  value = data.dns_srv_record_set.sip.srv.0.target
 }
 ```
 

--- a/website/docs/d/dns_txt_record_set.html.markdown
+++ b/website/docs/d/dns_txt_record_set.html.markdown
@@ -18,11 +18,11 @@ data "dns_txt_record_set" "hashicorp" {
 }
 
 output "hashi_txt" {
-  value = "${data.dns_txt_record_set.hashi.record}"
+  value = data.dns_txt_record_set.hashi.record
 }
 
 output "hashi_txts" {
-  value = "${join(",", data.dns_txt_record_set.hashi.records)}"
+  value = join(",", data.dns_txt_record_set.hashi.records)
 }
 ```
 


### PR DESCRIPTION
This updates the documentation to Terraform version 0.11+ syntax, which
allows constant expressions to be provided without the interpolation
syntax

Current documentation snippet:

```
output "google_addrs" {
  value = "${join(",", data.dns_a_record_set.google.addrs)}"
}
```

Terraform output:

```
Warning: Interpolation-only expressions are deprecated

  on test.tf line 71, in output "google_addrs":
  71:   value = "${join(",", data.dns_a_record_set.google.addrs)}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.
```