### PR TITLE
tests: Switch to hashicorptest.com DNS records for testing

### DIFF
--- a/internal/provider/data_dns_a_record_set_test.go
+++ b/internal/provider/data_dns_a_record_set_test.go
@@ -15,13 +15,13 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_a_record_set" "test" {
-  host = "127.0.0.1.nip.io"
+  host = "terraform-provider-dns-a.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "addrs.#", "1"),
 					resource.TestCheckTypeSetElemAttr(recordName, "addrs.*", "127.0.0.1"),
-					resource.TestCheckResourceAttr(recordName, "id", "127.0.0.1.nip.io"),
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-a.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_aaaa_record_set_test.go
+++ b/internal/provider/data_dns_aaaa_record_set_test.go
@@ -15,13 +15,13 @@ func TestAccDataDnsAAAARecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_aaaa_record_set" "test" {
-  host = "example.com"
+  host = "terraform-provider-dns-aaaa.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "addrs.#", "1"),
-					resource.TestCheckTypeSetElemAttr(recordName, "addrs.*", "2606:2800:220:1:248:1893:25c8:1946"),
-					resource.TestCheckResourceAttr(recordName, "id", "example.com"),
+					resource.TestCheckTypeSetElemAttr(recordName, "addrs.*", "::1"),
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-aaaa.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_cname_record_set_test.go
+++ b/internal/provider/data_dns_cname_record_set_test.go
@@ -15,12 +15,12 @@ func TestAccDataDnsCnameRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_cname_record_set" "test" {
-  host = "www.hashicorp.com"
+  host = "terraform-provider-dns-cname.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "cname", "cname.vercel-dns.com."),
-					resource.TestCheckResourceAttr(recordName, "id", "www.hashicorp.com"),
+					resource.TestCheckResourceAttr(recordName, "cname", "example.com."),
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-cname.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_mx_record_set_test.go
+++ b/internal/provider/data_dns_mx_record_set_test.go
@@ -15,31 +15,15 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_mx_record_set" "test" {
-  domain = "google.com"
+  domain = "terraform-provider-dns-mx.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "google.com"),
-					resource.TestCheckResourceAttr(recordName, "mx.#", "5"),
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-mx.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "mx.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
-						"exchange":   "aspmx.l.google.com.",
+						"exchange":   "example.com.",
 						"preference": "10",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
-						"exchange":   "alt1.aspmx.l.google.com.",
-						"preference": "20",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
-						"exchange":   "alt2.aspmx.l.google.com.",
-						"preference": "30",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
-						"exchange":   "alt3.aspmx.l.google.com.",
-						"preference": "40",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
-						"exchange":   "alt4.aspmx.l.google.com.",
-						"preference": "50",
 					}),
 				),
 			},

--- a/internal/provider/data_dns_ns_record_set_test.go
+++ b/internal/provider/data_dns_ns_record_set_test.go
@@ -15,14 +15,14 @@ func TestAccDataDnsNSRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_ns_record_set" "test" {
-  host = "terraform.io"
+  host = "terraform-provider-dns-ns.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "terraform.io"),
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-ns.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "nameservers.#", "2"),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "sam.ns.cloudflare.com."),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "zara.ns.cloudflare.com."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "adaline.ns.cloudflare.com."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "kenneth.ns.cloudflare.com."),
 				),
 			},
 		},

--- a/internal/provider/data_dns_srv_record_set_test.go
+++ b/internal/provider/data_dns_srv_record_set_test.go
@@ -15,17 +15,17 @@ func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_srv_record_set" "test" {
-  service = "_http._tcp.mxtoolbox.com"
+  service = "_sip._tls.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "_http._tcp.mxtoolbox.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "_sip._tls.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "srv.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(recordName, "srv.*", map[string]string{
-						"port":     "80",
-						"priority": "10",
-						"target":   "mxtoolbox.com.",
-						"weight":   "100",
+						"port":     "443",
+						"priority": "0",
+						"target":   "example.com.",
+						"weight":   "0",
 					}),
 				),
 			},

--- a/internal/provider/data_dns_txt_record_set_test.go
+++ b/internal/provider/data_dns_txt_record_set_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"os"
 	"regexp"
 	"testing"
 
@@ -9,11 +8,31 @@ import (
 )
 
 func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
-	// KEM: This test does not work in the GitHub Actions runner, although
-	// it passes locally and on Travis. More investigation needed.
-	if isInGitHubActions := os.Getenv("GITHUB_ACTIONS"); isInGitHubActions == "true" {
-		t.Skip()
-	}
+	recordName := "data.dns_txt_record_set.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "dns_txt_record_set" "test" {
+  host = "terraform-provider-dns-txt.hashicorptest.com"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-txt.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "record", "v=spf1 -all"),
+					resource.TestCheckResourceAttr(recordName, "records.#", "1"),
+					resource.TestCheckTypeSetElemAttr(recordName, "records.*", "v=spf1 -all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataDnsTxtRecordSet_512Byte(t *testing.T) {
+	t.Skipf("TODO: Large TXT record handling (greater than 512 bytes) will return errors in some environments. Reference: https://github.com/hashicorp/terraform-provider-dns/issues/157")
+
 	recordName := "data.dns_txt_record_set.test"
 
 	resource.UnitTest(t, resource.TestCase{


### PR DESCRIPTION
Reference: https://github.com/hashicorp/tf-eco-acctest-infrastructure/issues/61
Closes #112
Reference: https://github.com/hashicorp/terraform-provider-dns/pull/144
Closes #154
Reference: https://github.com/hashicorp/terraform-provider-dns/issues/157