### PR TITLE
ci: update acceptance tests to allow running on newer docker versions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       run: echo "127.0.0.1 ns.example.com" | sudo tee -a /etc/hosts
 
     - name: Install krb5-user
-      run: sudo apt-get install krb5-user
+      run: sudo apt-get update && sudo apt-get install krb5-user
 
     - name: Check out code
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
         terraform:
           - '0.12.*'
           - '0.13.*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         terraform:
           - '0.12.*'
           - '0.13.*'

--- a/internal/provider/acceptance.sh
+++ b/internal/provider/acceptance.sh
@@ -28,8 +28,8 @@ export DNS_UPDATE_PORT=15353
 
 # Run with no authentication
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.none:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \
@@ -40,8 +40,8 @@ cleanup_docker
 
 # Run with TSIG authentication (MD5)
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.md5:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \
@@ -52,8 +52,8 @@ cleanup_docker
 
 # Run with TSIG authentication (SHA256)
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.sha256:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \
@@ -68,16 +68,16 @@ export DNS_UPDATE_SERVER="ns.example.com"
 
 # Run with Kerberos authentication (password authentication)
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-p 127.0.0.1:18888:88 \
 	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \
@@ -88,16 +88,16 @@ cleanup_docker
 
 # Run with Kerberos authentication (keytab authentication)
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-p 127.0.0.1:18888:88 \
 	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \
@@ -108,16 +108,16 @@ cleanup_docker
 
 # Run with Kerberos authentication (session authentication)
 
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-p 127.0.0.1:18888:88 \
 	-p 127.0.0.1:18888:88/udp \
 	-p 127.0.0.1:464:464 \
 	-p 127.0.0.1:464:464/udp \
 	--rm --name kdc kdc || failed
-docker run -d --tmpfs /tmp --tmpfs /run \
-	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 	-v /etc/localtime:/etc/localtime:ro \
 	-v $PWD/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro \
 	-p 127.0.0.1:15353:53 \

--- a/internal/provider/testdata/Dockerfile
+++ b/internal/provider/testdata/Dockerfile
@@ -6,6 +6,11 @@ EXPOSE 464
 
 STOPSIGNAL SIGRTMIN+3
 
+# Systemd backport
+RUN yum -y install  wget
+RUN wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-for-centos-7/repo/epel-7/jsynacek-systemd-backports-for-centos-7-epel-7.repo -O /etc/yum.repos.d/jsynacek-systemd-centos-7.repo
+RUN yum -y update systemd ; yum clean all
+
 # Install Kerberos client packages and copy in configuration
 RUN yum install -y krb5-workstation && yum update -y && yum clean all
 COPY --chown=root:root krb5.conf /etc/krb5.conf

--- a/internal/provider/testdata/Dockerfile
+++ b/internal/provider/testdata/Dockerfile
@@ -39,6 +39,11 @@ EXPOSE 53
 
 STOPSIGNAL SIGRTMIN+3
 
+# Systemd backport
+RUN yum -y install  wget
+RUN wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-for-centos-7/repo/epel-7/jsynacek-systemd-backports-for-centos-7-epel-7.repo -O /etc/yum.repos.d/jsynacek-systemd-centos-7.repo
+RUN yum -y update systemd ; yum clean all
+
 # Install Kerberos client packages (should use cached KDC step above)
 RUN yum install -y krb5-workstation && yum update -y && yum clean all
 COPY --chown=root:root krb5.conf /etc/krb5.conf


### PR DESCRIPTION
closes #256 

## Background
> For reference, prior to this PR:
> - last successful run of tests: https://github.com/hashicorp/terraform-provider-dns/actions/runs/3468260802
> - first failed run of tests: https://github.com/hashicorp/terraform-provider-dns/actions/runs/3692207675

The provider acceptance tests started failing after `ubuntu-latest` was switched from `20.04` to `22.04`: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20221204.2

The acceptance tests run by [starting up](https://github.com/hashicorp/terraform-provider-dns/blob/main/internal/provider/acceptance.sh) a BIND DNS container, along with two sidecar containers that facilitate Kerberos functionality. Two of these containers run their processes using `systemd` inside a Centos 7 image, as seen in the [Dockerfile](https://github.com/hashicorp/terraform-provider-dns/blob/621f36b297df493978cfc43eda2ca73730fe626f/internal/provider/testdata/Dockerfile). 

After updating from ubuntu 22.04, the containers were no longer able to start-up `systemd` properly, causing `io/timeout` errors. This seems to be related to the introduction of `cgroupv2` functionality in Docker + Ubuntu, which requires a higher version of `systemd` then what was available in our Centos 7 image:
- **Root issue:** https://github.com/docker/for-mac/issues/6073
- **Docker engine change:** https://docs.docker.com/engine/release-notes/#20106
> cgroup2: Move cgroup v2 out of experimental [moby/moby#42263](https://github.com/moby/moby/pull/42263)
- **Docker Desktop change:** https://docs.docker.com/desktop/release-notes/#bug-fixes-and-minor-changes
> Docker Desktop now uses `cgroupv2`. If you need to run systemd in a container then:
>
> Ensure your version of systemd supports `cgroupv2`. It must be at least systemd 247. Consider upgrading any centos:7 images to centos:8
>
> Containers running systemd need the following options: `--privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw`

Coincidentally, `cgroupv2` support was added to Ubuntu 21.10, which would expose our issue - https://www.phoronix.com/news/Ubuntu-21.10-systemd-cgroup

## Solution
There are 3 possible solutions:
1. Switch the tests in GIthub Actions to use `ubuntu-20.04` explicitly, although running tests locally (on a higher version of docker) would not work.
2. Move away from using `systemd` / Centos to run the test DNS server, which would require refactoring the acceptance test setup
3. Update `systemd` in our existing setup to support `cgroupv2` via this [comment](https://github.com/docker/for-mac/issues/6073#issuecomment-1061207986)

I chose the 3rd option, although I am not an expert in this area, so I'm not sure if there are unintended consequences from solving it this way.

I ran the acceptance tests on my local machine as well to confirm we're still good there. `macOS Ventura 13.2, Docker Desktop v4.16.0`:
<details>
  <summary> <b>Local acceptance test output</b> </summary>
 
```bash
$ git rev-parse HEAD
9109cd5a13558d0544f0cd3fafde7b001b7ae9d4

$ ./internal/provider/acceptance.sh
+ command -v docker
+ command -v go
+ command -v kinit
+ command -v make
+ command -v terraform
+ grep -q ns.example.com /etc/hosts
+ docker buildx build --target kdc --tag kdc internal/provider/testdata/
[+] Building 54.8s (22/22) FINISHED
 => [internal] load build definition from Dockerfile                                                                         0.0s
 => => transferring dockerfile: 32B                                                                                          0.0s
 => [internal] load .dockerignore                                                                                            0.0s
 => => transferring context: 2B                                                                                              0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                             0.4s
 => [internal] load build context                                                                                            0.0s
 => => transferring context: 87B                                                                                             0.0s
 => [kdc  1/17] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b5  0.0s
 => CACHED [kdc  2/17] RUN yum -y install  wget                                                                              0.0s
 => CACHED [kdc  3/17] RUN wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-f  0.0s
 => CACHED [kdc  4/17] RUN yum -y update systemd ; yum clean all                                                             0.0s
 => CACHED [kdc  5/17] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                 0.0s
 => CACHED [kdc  6/17] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                       0.0s
 => CACHED [kdc  7/17] RUN chmod 644 /etc/krb5.conf                                                                          0.0s
 => [kdc  8/17] RUN yum install -y krb5-server && yum clean all                                                             46.9s
 => [kdc  9/17] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                               0.0s
 => [kdc 10/17] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                             0.0s
 => [kdc 11/17] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                                 0.2s
 => [kdc 12/17] RUN systemctl enable krb5kdc.service kadmin.service                                                          0.3s
 => [kdc 13/17] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -f 1)     1.3s
 => [kdc 14/17] RUN kadmin.local addprinc -pw password test                                                                  1.6s
 => [kdc 15/17] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                                   1.3s
 => [kdc 16/17] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                        1.2s
 => [kdc 17/17] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                               1.4s
 => exporting to image                                                                                                       0.1s
 => => exporting layers                                                                                                      0.1s
 => => writing image sha256:a163edb6f3284065fcf80edaf7402856807573ce0e5a981d0a131ea7151d9362                                 0.0s
 => => naming to docker.io/library/kdc                                                                                       0.0s
+ docker buildx build --target ns --tag ns internal/provider/testdata/
[+] Building 1.6s (27/28)
 => [internal] load build definition from Dockerfile                                                                         0.0s
 => => transferring dockerfile: 32B                                                                                          0.0s
 => [internal] load .dockerignore                                                                                            0.0s
 => => transferring context: 2B                                                                                              0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                             1.5s
 => [internal] load build context                                                                                            0.0s
 => => transferring context: 731B                                                                                            0.0s
 => [kdc  1/17] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b5  0.0s
 => CACHED [kdc  2/17] RUN yum -y install  wget                                                                              0.0s
 => CACHED [kdc  3/17] RUN wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-f  0.0s
 => CACHED [kdc  4/17] RUN yum -y update systemd ; yum clean all                                                             0.0s
 => CACHED [kdc  5/17] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                 0.0s
 => CACHED [kdc  6/17] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                       0.0s
 => CACHED [kdc  7/17] RUN chmod 644 /etc/krb5.conf                                                                          0.0s
 => CACHED [kdc  8/17] RUN yum install -y krb5-server && yum clean all                                                       0.0s
 => CACHED [kdc  9/17] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                        0.0s
 => CACHED [kdc 10/17] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                      0.0s
 => CACHED [kdc 11/17] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                          0.0s
 => CACHED [kdc 12/17] RUN systemctl enable krb5kdc.service kadmin.service                                                   0.0s
 => CACHED [kdc 13/17] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -  0.0s
 => CACHED [kdc 14/17] RUN kadmin.local addprinc -pw password test                                                           0.0s
 => CACHED [kdc 15/17] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                            0.0s
 => CACHED [kdc 16/17] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                 0.0s
 => CACHED [kdc 17/17] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                        0.0s
 => CACHED [ns  8/13] RUN yum install -y bind bind-utils && yum clean all                                                    0.0s
 => [ns  9/13] COPY --from=kdc --chown=root:named /etc/named.keytab /etc/named.keytab                                        0.0s
 => [ns 10/13] RUN chmod 640 /etc/named.keytab                                                                               0.2s
 => [ns 11/13] RUN systemctl enable named.service                                                                            0.4s
 => [ns 12/13] COPY --chown=named:named db.* /var/named/dynamic/                                                             0.0s
 => [ns 13/13] RUN chmod 644 /var/named/dynamic/db.*                                                                         0.3s
 => exporting to image                                                                                                       0.0s
 => => exporting layers                                                                                                      0.0s
 => => writing image sha256:9955c07735879208460696b75e9f480aa2a4d4f4851bb4168790de3f66b10665                                 0.0s
 => => naming to docker.io/library/ns                                                                                        0.0s
+ docker buildx build --target keytab --output type=local,dest=internal/provider/testdata/ internal/provider/testdata/
[+] Building 0.5s (23/23) FINISHED
 => [internal] load build definition from Dockerfile                                                                         0.0s
 => => transferring dockerfile: 32B                                                                                          0.0s
 => [internal] load .dockerignore                                                                                            0.0s
 => => transferring context: 2B                                                                                              0.0s
 => [internal] load metadata for docker.io/centos/systemd:latest                                                             0.4s
 => [kdc  1/17] FROM docker.io/centos/systemd:latest@sha256:09db0255d215ca33710cc42e1a91b9002637eeef71322ca641947e65b7d53b5  0.0s
 => [internal] load build context                                                                                            0.0s
 => => transferring context: 87B                                                                                             0.0s
 => CACHED [kdc  2/17] RUN yum -y install  wget                                                                              0.0s
 => CACHED [kdc  3/17] RUN wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-f  0.0s
 => CACHED [kdc  4/17] RUN yum -y update systemd ; yum clean all                                                             0.0s
 => CACHED [kdc  5/17] RUN yum install -y krb5-workstation && yum update -y && yum clean all                                 0.0s
 => CACHED [kdc  6/17] COPY --chown=root:root krb5.conf /etc/krb5.conf                                                       0.0s
 => CACHED [kdc  7/17] RUN chmod 644 /etc/krb5.conf                                                                          0.0s
 => CACHED [kdc  8/17] RUN yum install -y krb5-server && yum clean all                                                       0.0s
 => CACHED [kdc  9/17] COPY --chown=root:root kdc.conf /var/kerberos/krb5kdc/kdc.conf                                        0.0s
 => CACHED [kdc 10/17] COPY --chown=root:root kadm5.acl /var/kerberos/krb5kdc/kadm5.acl                                      0.0s
 => CACHED [kdc 11/17] RUN chmod 600 /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/kadm5.acl                          0.0s
 => CACHED [kdc 12/17] RUN systemctl enable krb5kdc.service kadmin.service                                                   0.0s
 => CACHED [kdc 13/17] RUN kdb5_util create -s -r EXAMPLE.COM -P $(echo ${RANDOM}${RANDOM}${RANDOM} | md5sum | cut -d ' ' -  0.0s
 => CACHED [kdc 14/17] RUN kadmin.local addprinc -pw password test                                                           0.0s
 => CACHED [kdc 15/17] RUN kadmin.local ktadd -norandkey -k /etc/test.keytab test                                            0.0s
 => CACHED [kdc 16/17] RUN kadmin.local addprinc -randkey DNS/ns.example.com                                                 0.0s
 => CACHED [kdc 17/17] RUN kadmin.local ktadd -k /etc/named.keytab DNS/ns.example.com                                        0.0s
 => [keytab 1/1] COPY --from=kdc /etc/test.keytab /test.keytab                                                               0.0s
 => exporting to client                                                                                                      0.0s
 => => copying files 526B                                                                                                    0.0s
+ export DNS_UPDATE_SERVER=127.0.0.1
+ DNS_UPDATE_SERVER=127.0.0.1
+ export DNS_UPDATE_PORT=15353
+ DNS_UPDATE_PORT=15353
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.none:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
3d8e3c9f35bc2aff598970ecd71ec6771c1ea5b5b27155de0803f7d339ccd5c6
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.91s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.49s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.52s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.67s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.68s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.48s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (0.50s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.66s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.67s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/leading-zero
=== CONT  TestStripLeadingZeros/double-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (2.01s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.96s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.44s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.03s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (1.47s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.05s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (1.53s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (2.13s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	21.952s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.md5:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
cd31bf9760747b92669fb70bd38c7f2050b116bc89e30041139d7477ed6f924f
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-md5
+ DNS_UPDATE_KEYSECRET=mX9XKfw/RXBj5ZnZKMy4Nw==
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.47s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.45s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.43s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.60s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.69s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.44s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (0.48s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.59s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.64s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/leading-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (2.14s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.51s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.45s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.00s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (1.45s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.00s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (1.52s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (1.99s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	20.141s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.sha256:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
a0a4c61b41eb2d79a449234782b5400a87fb7ead47d56ac50a17bcf9bcfa6170
+ DNS_UPDATE_KEYNAME=tsig.example.com.
+ DNS_UPDATE_KEYALGORITHM=hmac-sha256
+ DNS_UPDATE_KEYSECRET=UHeh4Iv/DVmPhi6LqCPDs6PixnyjLH4fjGESBjYnOyE=
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.46s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.44s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.43s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.60s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.60s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.43s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (0.49s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.60s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.62s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/leading-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (2.06s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.43s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.47s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.05s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (2.04s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.55s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (1.56s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (2.09s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	21.233s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
Error response from daemon: No such container: kdc
+ :
+ export KRB5_CONFIG=/Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ KRB5_CONFIG=/Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/krb5.conf
+ export DNS_UPDATE_REALM=EXAMPLE.COM
+ DNS_UPDATE_REALM=EXAMPLE.COM
+ export DNS_UPDATE_SERVER=ns.example.com
+ DNS_UPDATE_SERVER=ns.example.com
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
7fcb823d3580dd9a68788c46302a96312aeb8b3f1ac03c3677568707ecb74420
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
f66362dcbaa9410911c6640c2542291166c006d34911dd1eec9190787b3c524e
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_PASSWORD=password
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.45s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.44s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.44s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.62s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.59s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.42s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (0.45s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.65s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.60s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/leading-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (3.13s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.88s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.75s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.49s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (1.87s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.68s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (2.05s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (2.63s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	24.450s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2fce88c8d7c941b09a7202a9ad144d6fd881f72a35b92ad66a09d044f7d0ddd8
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
610fa3875442fded2f56e6c297e541f156c44399655502195b1f25ee002b2947
+ DNS_UPDATE_USERNAME=test
+ DNS_UPDATE_KEYTAB=/Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/test.keytab
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.52s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.48s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.45s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.57s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.57s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.40s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (0.46s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.56s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.57s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/leading-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (2.37s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.88s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.79s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.41s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (2.26s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.34s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (1.79s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (2.33s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	23.060s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -p 127.0.0.1:18888:88 -p 127.0.0.1:18888:88/udp -p 127.0.0.1:464:464 -p 127.0.0.1:464:464/udp --rm --name kdc kdc
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
463d7cb33b6c0522b67238c01d1aa0113a8338963b2e6be23fe8f9e8e4f6a221
+ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /etc/localtime:/etc/localtime:ro -v /Users/austin.valle/code/terraform-provider-dns/internal/provider/testdata/named.conf.kerberos:/etc/named.conf:ro -p 127.0.0.1:15353:53 -p 127.0.0.1:15353:53/udp --rm --name ns --hostname ns.example.com ns
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
b491d7f65dee391b9e4f75579a6a896ec9071c7fb531536aa5028df8de1af9e2
+ echo password
+ kinit --password-file=STDIN test@EXAMPLE.COM
+ GO111MODULE=on
+ make testacc TEST=./internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider -v  -timeout 120m
=== RUN   TestAccDataDnsARecordSet_Basic
--- PASS: TestAccDataDnsARecordSet_Basic (0.43s)
=== RUN   TestAccDataDnsAAAARecordSet_Basic
--- PASS: TestAccDataDnsAAAARecordSet_Basic (0.40s)
=== RUN   TestAccDataDnsCnameRecordSet_Basic
--- PASS: TestAccDataDnsCnameRecordSet_Basic (0.41s)
=== RUN   TestAccDataDnsMXRecordSet_Basic
--- PASS: TestAccDataDnsMXRecordSet_Basic (0.56s)
=== RUN   TestAccDataDnsNSRecordSet_Basic
--- PASS: TestAccDataDnsNSRecordSet_Basic (0.72s)
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.41s)
=== RUN   TestAccDataDnsSRVRecordSet_Basic
--- PASS: TestAccDataDnsSRVRecordSet_Basic (1.00s)
=== RUN   TestAccDataDnsTxtRecordSet_Basic
--- PASS: TestAccDataDnsTxtRecordSet_Basic (0.55s)
=== RUN   TestAccDataDnsTxtRecordSet_512Byte
--- PASS: TestAccDataDnsTxtRecordSet_512Byte (0.56s)
=== RUN   TestHashIPString
--- PASS: TestHashIPString (0.00s)
=== RUN   TestStripLeadingZeros
=== RUN   TestStripLeadingZeros/single-zero
=== PAUSE TestStripLeadingZeros/single-zero
=== RUN   TestStripLeadingZeros/double-zero
=== PAUSE TestStripLeadingZeros/double-zero
=== RUN   TestStripLeadingZeros/triple-zero
=== PAUSE TestStripLeadingZeros/triple-zero
=== RUN   TestStripLeadingZeros/leading-zero
=== PAUSE TestStripLeadingZeros/leading-zero
=== CONT  TestStripLeadingZeros/single-zero
=== CONT  TestStripLeadingZeros/triple-zero
=== CONT  TestStripLeadingZeros/double-zero
=== CONT  TestStripLeadingZeros/leading-zero
--- PASS: TestStripLeadingZeros (0.00s)
    --- PASS: TestStripLeadingZeros/single-zero (0.00s)
    --- PASS: TestStripLeadingZeros/triple-zero (0.00s)
    --- PASS: TestStripLeadingZeros/double-zero (0.00s)
    --- PASS: TestStripLeadingZeros/leading-zero (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (2.27s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (2.61s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (1.68s)
=== RUN   TestAccDnsMXRecordSet_Basic
--- PASS: TestAccDnsMXRecordSet_Basic (2.32s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (1.67s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (2.29s)
=== RUN   TestAccDnsSRVRecordSet_Basic
--- PASS: TestAccDnsSRVRecordSet_Basic (1.75s)
=== RUN   TestAccDnsTXTRecordSet_Basic
--- PASS: TestAccDnsTXTRecordSet_Basic (2.30s)
=== RUN   TestValidateZone
--- PASS: TestValidateZone (0.00s)
=== RUN   TestValidateName
--- PASS: TestValidateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-dns/internal/provider	22.288s
+ cleanup_docker
+ docker stop ns
ns
+ docker stop kdc
kdc
```
</details>