### PR TITLE
Fix typo in dns_txt_record_set documentation example

### DIFF
--- a/website/docs/d/dns_a_record_set.html.markdown
+++ b/website/docs/d/dns_a_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_a_record_set" "google" {
 }
 
 output "google_addrs" {
-  value = "${join(",", data.dns_a_record_set.google.addrs)}"
+  value = join(",", data.dns_a_record_set.google.addrs)
 }
 ```
 

--- a/website/docs/d/dns_aaaa_record_set.html.markdown
+++ b/website/docs/d/dns_aaaa_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_aaaa_record_set" "google" {
 }
 
 output "google_addrs" {
-  value = "${join(",", data.dns_aaaa_record_set.google.addrs)}"
+  value = join(",", data.dns_aaaa_record_set.google.addrs)
 }
 ```
 

--- a/website/docs/d/dns_cname_record_set.html.markdown
+++ b/website/docs/d/dns_cname_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_cname_record_set" "hashicorp" {
 }
 
 output "hashi_cname" {
-  value = "${data.dns_cname_record_set.hashicorp.cname}"
+  value = data.dns_cname_record_set.hashicorp.cname
 }
 ```
 

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_mx_record_set" "mail" {
 }
 
 output "mailserver" {
-  value = "${data.dns_mx_record_set.mail.mx.0.exchange}"
+  value = data.dns_mx_record_set.mail.mx[0].exchange
 }
 ```
 
@@ -33,3 +33,5 @@ The following attributes are exported:
 
  * `id` - Set to `service`.
  * `mx` - A list of records. They are sorted by ascending preference then alphabetically by exchange to stay consistent across runs.
+   * `exchange` - Fully qualified domain name (FQDN) of the mail exchanger.
+   * `preference` - Preference value of this MX record.

--- a/website/docs/d/dns_ns_record_set.html.markdown
+++ b/website/docs/d/dns_ns_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_ns_record_set" "google" {
 }
 
 output "google_nameservers" {
-  value = "${join(",", data.dns_ns_record_set.google.nameservers)}"
+  value = join(",", data.dns_ns_record_set.google.nameservers)
 }
 ```
 
@@ -32,5 +32,4 @@ The following arguments are supported:
 The following attributes are exported:
 
  * `id` - Set to `host`.
-
  * `nameservers` - A list of nameservers. Nameservers are always sorted to avoid constant changing plans.

--- a/website/docs/d/dns_ptr_record_set.html.markdown
+++ b/website/docs/d/dns_ptr_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_ptr_record_set" "hashicorp" {
 }
 
 output "hashi_ptr" {
-  value = "${data.dns_ptr_record_set.hashicorp.ptr}"
+  value = data.dns_ptr_record_set.hashicorp.ptr
 }
 ```
 
@@ -32,7 +32,6 @@ The following arguments are supported:
 The following attributes are exported:
 
  * `id` - Set to `ip_address`.
-
  * `ptr` - A PTR record associated with `ip_address`.
 
  __NOTE__: Only the first result is taken from the query.

--- a/website/docs/d/dns_srv_record_set.html.markdown
+++ b/website/docs/d/dns_srv_record_set.html.markdown
@@ -17,7 +17,7 @@ data "dns_srv_record_set" "sip" {
 }
 
 output "sipserver" {
-  value = "${data.dns_srv_record_set.sip.srv.0.target}"
+  value = data.dns_srv_record_set.sip.srv[0].target
 }
 ```
 

--- a/website/docs/d/dns_txt_record_set.html.markdown
+++ b/website/docs/d/dns_txt_record_set.html.markdown
@@ -17,11 +17,11 @@ data "dns_txt_record_set" "hashicorp" {
 }
 
 output "hashi_txt" {
-  value = "${data.dns_txt_record_set.hashi.record}"
+  value = data.dns_txt_record_set.hashicorp.record
 }
 
 output "hashi_txts" {
-  value = "${join(",", data.dns_txt_record_set.hashi.records)}"
+  value = join(",", data.dns_txt_record_set.hashicorp.records)
 }
 ```
 
@@ -36,7 +36,5 @@ The following arguments are supported:
 The following attributes are exported:
 
  * `id` - Set to `host`.
-
  * `record` - The first TXT record.
-
  * `records` - A list of TXT records.


### PR DESCRIPTION
* Remove unnecessary string interpolation and other style updates