### PR TITLE
Correctly handle DNS client configuration

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230419-160433.yaml
+++ b/.changes/unreleased/BUG FIXES-20230419-160433.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'provider: Prevents panics resulting from provider configuration errors'
+time: 2023-04-19T16:04:33.127975-04:00
+custom:
+  Issue: "289"

--- a/.changes/unreleased/BUG FIXES-20230419-161012.yaml
+++ b/.changes/unreleased/BUG FIXES-20230419-161012.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'provider: Correctly configures DNS client from provider configurations'
+body: 'provider: Correctly configures DNS client from provider configuration via Terraform configuration'
 time: 2023-04-19T16:10:12.411987-04:00
 custom:
   Issue: "290"

--- a/.changes/unreleased/BUG FIXES-20230419-161012.yaml
+++ b/.changes/unreleased/BUG FIXES-20230419-161012.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'provider: Correctly configures DNS client from provider configurations'
+time: 2023-04-19T16:10:12.411987-04:00
+custom:
+  Issue: "290"

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bodgit/tsig"
 	"github.com/bodgit/tsig/gss"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/miekg/dns"
 )
 
@@ -47,7 +46,7 @@ type DNSClient struct {
 }
 
 // Client configures and returns a fully initialized DNSClient.
-func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
+func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	tflog.Info(ctx, "Building DNSClient config structure")
 
 	var client DNSClient
@@ -58,10 +57,10 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	if c.gssapi && // GSSAPI requested
 		!(c.realm != "" && ((c.username == "" && c.password == "" && c.keytab == "") || // Rely on current user session
 			(c.username != "" && (c.password != "" || c.keytab != "")))) { // Supplied credentials with either password or keytab
-		return nil, diag.Errorf("Error configuring provider: when using GSSAPI, \"realm\", \"username\" and either \"password\" or \"keytab\" should be non empty")
+		return nil, fmt.Errorf("Error configuring provider: when using GSSAPI, \"realm\", \"username\" and either \"password\" or \"keytab\" should be non empty")
 	} else if !((c.keyname == "" && c.keysecret == "" && c.keyalgo == "") || // No TSIG required
 		(c.keyname != "" && c.keysecret != "" && c.keyalgo != "")) { // Supplied key name, secret and algorithm
-		return nil, diag.Errorf("Error configuring provider: when using authentication, \"key_name\", \"key_secret\" and \"key_algorithm\" should be non empty")
+		return nil, fmt.Errorf("Error configuring provider: when using authentication, \"key_name\", \"key_secret\" and \"key_algorithm\" should be non empty")
 	}
 
 	client.c = new(dns.Client)
@@ -75,21 +74,21 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	client.keytab = c.keytab
 	if !c.gssapi && c.keyname != "" {
 		if !dns.IsFqdn(c.keyname) {
-			return nil, diag.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")
+			return nil, fmt.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")
 		}
 		keyname := strings.ToLower(c.keyname)
 		client.keyname = keyname
 		client.keysecret = c.keysecret
 		keyalgo, err := convertHMACAlgorithm(c.keyalgo)
 		if err != nil {
-			return nil, diag.Errorf("Error configuring provider: %s", err)
+			return nil, fmt.Errorf("Error configuring provider: %s", err)
 		}
 		client.keyalgo = keyalgo
 		client.c.TsigProvider = tsig.HMAC{keyname: c.keysecret}
 	} else if c.gssapi {
 		g, err := gss.NewClient(client.c)
 		if err != nil {
-			return nil, diag.Errorf("Error initializing GSS library: %s", err)
+			return nil, fmt.Errorf("Error initializing GSS library: %s", err)
 		}
 
 		client.gssClient = g

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -332,7 +332,12 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		keytab:    keytab,
 	}
 
-	return config.Client(ctx)
+	dnsClient, err := config.Client(ctx)
+	if err != nil {
+		return dnsClient, diag.Errorf(err.Error())
+	}
+
+	return dnsClient, nil
 }
 
 func getAVal(record interface{}) (string, int, error) {

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -184,7 +184,6 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	server = providerUpdateConfig[0].Server.ValueString()
 	port = int(providerUpdateConfig[0].Port.ValueInt64())
 	transport = providerUpdateConfig[0].Transport.ValueString()
-	timeout = providerUpdateConfig[0].Timeout.ValueString()
 	retries = int(providerUpdateConfig[0].Retries.ValueInt64())
 	keyname = providerUpdateConfig[0].KeyName.ValueString()
 	keyalgo = providerUpdateConfig[0].KeyAlgorithm.ValueString()

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -163,6 +163,7 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	var port, retries int
 	var duration time.Duration
 	var gssapi bool
+	var configErr error
 
 	providerUpdateConfig := make([]providerUpdateModel, 1)
 	providerGssapiConfig := make([]providerGssapiModel, 1)
@@ -315,7 +316,10 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		keytab:    keytab,
 	}
 
-	resp.ResourceData, _ = config.Client(ctx)
+	resp.ResourceData, configErr = config.Client(ctx)
+	if configErr != nil {
+		resp.Diagnostics.AddError("Error initializing DNS Client:", configErr.Error())
+	}
 }
 
 func (p *dnsProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -60,10 +60,10 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	//v := os.Getenv("DNS_UPDATE_SERVER")
-	//if v == "" {
-	//	t.Fatal("DNS_UPDATE_SERVER must be set for acceptance tests")
-	//}
+	v := os.Getenv("DNS_UPDATE_SERVER")
+	if v == "" {
+		t.Fatal("DNS_UPDATE_SERVER must be set for acceptance tests")
+	}
 }
 
 func testResourceFQDN(name, zone string) string {


### PR DESCRIPTION
Fixes: #289
Fixes: #290 

The migration to `terraform-plugin-framework` in `v3.3.0` introduced a panic from not correctly handling the errors returned from `config.client()` which causes the `exchange()` to panic when trying to access a `*DNSClient` which is set to `nil`. This PR handles and returns the error to the user, preventing the panic. An additional test `TestAccProvider_InvalidClientConfig()` has been added to test this scenario.

It also introduced a bug where the `DNSClient` was not being configured with the user's Terraform configuration and only using the set environment variables. This PR correctly sets the `DNSClient` using the config values and uses environment variables to set a variable only if the variable isn't already set in the user Terraform configuration.
