### PR TITLE
internal/provider: Initial unit testing for provider Configure method

### DIFF
--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -361,11 +362,46 @@ type providerUpdateModel struct {
 	Gssapi       types.List   `tfsdk:"gssapi"` //providerGssapiModel
 }
 
+func (m providerUpdateModel) attributeType() attr.Type {
+	return types.ObjectType{AttrTypes: m.attributeTypes()}
+}
+
+func (m providerUpdateModel) attributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"gssapi": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: providerGssapiModel{}.attributeTypes(),
+			},
+		},
+		"key_name":      types.StringType,
+		"key_algorithm": types.StringType,
+		"key_secret":    types.StringType,
+		"port":          types.Int64Type,
+		"server":        types.StringType,
+		"retries":       types.Int64Type,
+		"timeout":       types.StringType,
+		"transport":     types.StringType,
+	}
+}
+
 type providerGssapiModel struct {
 	Realm    types.String `tfsdk:"realm"`
 	Username types.String `tfsdk:"username"`
 	Password types.String `tfsdk:"password"`
 	Keytab   types.String `tfsdk:"keytab"`
+}
+
+func (m providerGssapiModel) attributeType() attr.Type {
+	return types.ObjectType{AttrTypes: m.attributeTypes()}
+}
+
+func (m providerGssapiModel) attributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"keytab":   types.StringType,
+		"password": types.StringType,
+		"realm":    types.StringType,
+		"username": types.StringType,
+	}
 }
 
 func resourceDnsImport_framework(id string, client *DNSClient) (dnsConfig, diag.Diagnostics) {

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -362,16 +362,14 @@ type providerUpdateModel struct {
 	Gssapi       types.List   `tfsdk:"gssapi"` //providerGssapiModel
 }
 
-func (m providerUpdateModel) attributeType() attr.Type {
-	return types.ObjectType{AttrTypes: m.attributeTypes()}
+func (m providerUpdateModel) objectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: m.objectAttributeTypes()}
 }
 
-func (m providerUpdateModel) attributeTypes() map[string]attr.Type {
+func (m providerUpdateModel) objectAttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"gssapi": types.ListType{
-			ElemType: types.ObjectType{
-				AttrTypes: providerGssapiModel{}.attributeTypes(),
-			},
+			ElemType: providerGssapiModel{}.objectType(),
 		},
 		"key_name":      types.StringType,
 		"key_algorithm": types.StringType,
@@ -391,11 +389,11 @@ type providerGssapiModel struct {
 	Keytab   types.String `tfsdk:"keytab"`
 }
 
-func (m providerGssapiModel) attributeType() attr.Type {
-	return types.ObjectType{AttrTypes: m.attributeTypes()}
+func (m providerGssapiModel) objectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: m.objectAttributeTypes()}
 }
 
-func (m providerGssapiModel) attributeTypes() map[string]attr.Type {
+func (m providerGssapiModel) objectAttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"keytab":   types.StringType,
 		"password": types.StringType,

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -76,7 +76,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 		"no-config-or-env": {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -94,12 +94,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -132,12 +132,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -169,7 +169,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			},
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -189,7 +189,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			},
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -206,12 +206,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -244,12 +244,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -281,7 +281,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			},
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -299,12 +299,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -337,12 +337,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListValueMust(
-						providerUpdateModel{}.attributeType(),
+						providerUpdateModel{}.objectType(),
 						[]attr.Value{
 							types.ObjectValueMust(
-								providerUpdateModel{}.attributeTypes(),
+								providerUpdateModel{}.objectAttributeTypes(),
 								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
 									"key_name":      types.StringNull(),
 									"key_algorithm": types.StringNull(),
 									"key_secret":    types.StringNull(),
@@ -374,7 +374,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			},
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
 				}),
 			},
 			expected: &provider.ConfigureResponse{

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -54,6 +54,20 @@ func TestDnsProviderConfigure(t *testing.T) {
 
 	schema := schemaResp.Schema
 
+	// Prevent external environment variable values from affecting this test
+	t.Setenv("DNS_UPDATE_KEYALGORITHM", "")
+	t.Setenv("DNS_UPDATE_KEYNAME", "")
+	t.Setenv("DNS_UPDATE_KEYSECRET", "")
+	t.Setenv("DNS_UPDATE_KEYTAB", "")
+	t.Setenv("DNS_UPDATE_PASSWORD", "")
+	t.Setenv("DNS_UPDATE_PORT", "")
+	t.Setenv("DNS_UPDATE_REALM", "")
+	t.Setenv("DNS_UPDATE_RETRIES", "")
+	t.Setenv("DNS_UPDATE_SERVER", "")
+	t.Setenv("DNS_UPDATE_TRANSPORT", "")
+	t.Setenv("DNS_UPDATE_TIMEOUT", "")
+	t.Setenv("DNS_UPDATE_USERNAME", "")
+
 	testCases := map[string]struct {
 		env      map[string]string
 		request  provider.ConfigureRequest

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -1,0 +1,397 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/miekg/dns"
+)
+
+// testProviderSchemaConfig returns a tfsdk.Config for the given schema.
+func testProviderSchemaConfig(t *testing.T, ctx context.Context, schema schema.Schema, values map[string]attr.Value) tfsdk.Config {
+	t.Helper()
+
+	schemaType := schema.Type()
+	objectType, ok := schemaType.(types.ObjectType)
+
+	if !ok {
+		t.Fatalf("expected schema type of types.Object, got: %T", schemaType)
+	}
+
+	objectValue := types.ObjectValueMust(objectType.AttributeTypes(), values)
+	tfTypesValue, err := objectValue.ToTerraformValue(ctx)
+
+	if err != nil {
+		t.Fatalf("unexpected error converting to tftypes: %s", err)
+	}
+
+	return tfsdk.Config{
+		Schema: schema,
+		Raw:    tfTypesValue,
+	}
+}
+
+// nolint:paralleltest // includes environment variable testing
+func TestDnsProviderConfigure(t *testing.T) {
+	ctx := context.Background()
+	schemaReq := provider.SchemaRequest{}
+	schemaResp := &provider.SchemaResponse{}
+	testProvider := NewFrameworkProvider()
+
+	testProvider.Schema(ctx, schemaReq, schemaResp)
+
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	schema := schemaResp.Schema
+
+	testCases := map[string]struct {
+		env      map[string]string
+		request  provider.ConfigureRequest
+		expected *provider.ConfigureResponse
+	}{
+		"no-config-or-env": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "udp",
+				},
+			},
+		},
+		"update-port-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Value(1053),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":1053",
+					transport: "udp",
+				},
+			},
+		},
+		"update-port-config-and-env": {
+			env: map[string]string{
+				"DNS_UPDATE_PORT": "2053",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Value(1053),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":1053",
+					transport: "udp",
+				},
+			},
+		},
+		"update-port-env": {
+			env: map[string]string{
+				"DNS_UPDATE_PORT": "1053",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":1053",
+					transport: "udp",
+				},
+			},
+		},
+		"update-port-env-invalid": {
+			env: map[string]string{
+				"DNS_UPDATE_PORT": "not-an-int",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid DNS_UPDATE_PORT environment variable:",
+						"strconv.Atoi: parsing \"not-an-int\": invalid syntax",
+					),
+				},
+				ResourceData: nil,
+			},
+		},
+		"update-server-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringValue("example.com"),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  "example.com:53",
+					transport: "udp",
+				},
+			},
+		},
+		"update-server-config-and-env": {
+			env: map[string]string{
+				"DNS_UPDATE_SERVER": "example.org",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringValue("example.com"),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  "example.com:53",
+					transport: "udp",
+				},
+			},
+		},
+		"update-server-env": {
+			env: map[string]string{
+				"DNS_UPDATE_SERVER": "example.com",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  "example.com:53",
+					transport: "udp",
+				},
+			},
+		},
+		"update-transport-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringValue("tcp"),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "tcp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "tcp",
+				},
+			},
+		},
+		"update-transport-config-and-env": {
+			env: map[string]string{
+				"DNS_UPDATE_TRANSPORT": "tcp6",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.attributeType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.attributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.attributeType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringValue("tcp"),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "tcp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "tcp",
+				},
+			},
+		},
+		"update-transport-env": {
+			env: map[string]string{
+				"DNS_UPDATE_TRANSPORT": "tcp",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.attributeType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "tcp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "tcp",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		// nolint:paralleltest // includes environment variable testing
+		t.Run(name, func(t *testing.T) {
+			for envKey, envValue := range testCase.env {
+				t.Setenv(envKey, envValue)
+			}
+
+			got := &provider.ConfigureResponse{}
+
+			testProvider.Configure(ctx, testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected, cmp.AllowUnexported(DNSClient{}), cmpopts.IgnoreUnexported(dns.Client{})); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-dns/issues/290

Introduce unit testing for the complex `(dnsProvider).Configure()` method. This initial testing covers no configuration/environment variables and the `update` list block `port`, `server`, and `transport` attributes (along with their associated environment variables).