### PR TITLE
provider: Test using mux server, prevent mux server errors, and add provider environment variables to descriptions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230421-143032.yaml
+++ b/.changes/unreleased/BUG FIXES-20230421-143032.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'provider: Prevented `Invalid Provider Server Combination` errors when configured
+  via environment variables'
+time: 2023-04-21T14:30:32.047485-04:00
+custom:
+  Issue: "293"

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,36 +57,30 @@ resource "dns_a_record_set" "www" {
 
 ### Optional
 
-- `update` (Block List, Max: 1) When the provider is used for DNS updates, this block is required. (see [below for nested schema](#nestedblock--update))
+- `update` (Block List) When the provider is used for DNS updates, this block is required. Only one `update` block may be in the configuration. (see [below for nested schema](#nestedblock--update))
 
 <a id="nestedblock--update"></a>
 ### Nested Schema for `update`
 
-Required:
-
-- `server` (String) The hostname or IP address of the DNS server to send updates to.
-
 Optional:
 
-- `gssapi` (Block List, Max: 1) A `gssapi` block. Only one `gssapi` block may be in the configuration. Conflicts with use of `key_name`, `key_algorithm` and `key_secret`. (see [below for nested schema](#nestedblock--update--gssapi))
-- `key_algorithm` (String) Required if `key_name` is set. When using TSIG authentication, the algorithm to use for HMAC. Valid values are `hmac-md5`, `hmac-sha1`, `hmac-sha256` or `hmac-sha512`.
-- `key_name` (String) The name of the TSIG key used to sign the DNS update messages.
+- `gssapi` (Block List) A `gssapi` block. Only one `gssapi` block may be in the configuration. Conflicts with use of `key_name`, `key_algorithm` and `key_secret`. (see [below for nested schema](#nestedblock--update--gssapi))
+- `key_algorithm` (String) Required if `key_name` is set. When using TSIG authentication, the algorithm to use for HMAC. Valid values are `hmac-md5`, `hmac-sha1`, `hmac-sha256` or `hmac-sha512`. Value can also be sourced from the DNS_UPDATE_KEYALGORITHM environment variable.
+- `key_name` (String) The name of the TSIG key used to sign the DNS update messages. Value can also be sourced from the DNS_UPDATE_KEYNAME environment variable.
 - `key_secret` (String) Required if `key_name` is set
-A Base64-encoded string containing the shared secret to be used for TSIG.
-- `port` (Number) The target UDP port on the server where updates are sent to. Defaults to `53`.
-- `retries` (Number) How many times to retry on connection timeout. Defaults to `3`.
-- `timeout` (String) Timeout for DNS queries. Valid values are durations expressed as `500ms`, etc. or a plain number which is treated as whole seconds.
-- `transport` (String) Transport to use for DNS queries. Valid values are `udp`, `udp4`, `udp6`, `tcp`, `tcp4`, or `tcp6`. Any UDP transport will retry automatically with the equivalent TCP transport in the event of a truncated response. Defaults to `udp`.
+A Base64-encoded string containing the shared secret to be used for TSIG. Value can also be sourced from the DNS_UPDATE_KEYSECRET environment variable.
+- `port` (Number) The target UDP port on the server where updates are sent to. Defaults to `53`. Value can also be sourced from the DNS_UPDATE_PORT environment variable.
+- `retries` (Number) How many times to retry on connection timeout. Defaults to `3`. Value can also be sourced from the DNS_UPDATE_RETRIES environment variable.
+- `server` (String) The hostname or IP address of the DNS server to send updates to. Value can also be sourced from the DNS_UPDATE_SERVER environment variable.
+- `timeout` (String) Timeout for DNS queries. Valid values are durations expressed as `500ms`, etc. or a plain number which is treated as whole seconds. Value can also be sourced from the DNS_UPDATE_TIMEOUT environment variable.
+- `transport` (String) Transport to use for DNS queries. Valid values are `udp`, `udp4`, `udp6`, `tcp`, `tcp4`, or `tcp6`. Any UDP transport will retry automatically with the equivalent TCP transport in the event of a truncated response. Defaults to `udp`. Value can also be sourced from the DNS_UPDATE_TRANSPORT environment variable.
 
 <a id="nestedblock--update--gssapi"></a>
 ### Nested Schema for `update.gssapi`
 
-Required:
-
-- `realm` (String) The Kerberos realm or Active Directory domain.
-
 Optional:
 
-- `keytab` (String) This or `password` is required if `username` is set, not supported on Windows. The path to a keytab file containing a key for `username`.
-- `password` (String, Sensitive) This or `keytab` is required if `username` is set. The matching password for `username`.
-- `username` (String) The name of the user to authenticate as. If not set the current user session will be used.
+- `keytab` (String) This or `password` is required if `username` is set, not supported on Windows. The path to a keytab file containing a key for `username`. Value can also be sourced from the DNS_UPDATE_KEYTAB environment variable.
+- `password` (String, Sensitive) This or `keytab` is required if `username` is set. The matching password for `username`. Value can also be sourced from the DNS_UPDATE_PASSWORD environment variable.
+- `realm` (String) The Kerberos realm or Active Directory domain. Value can also be sourced from the DNS_UPDATE_REALM environment variable.
+- `username` (String) The name of the user to authenticate as. If not set the current user session will be used. Value can also be sourced from the DNS_UPDATE_USERNAME environment variable.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,16 +28,16 @@ func New() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"update": {
 				Type:        schema.TypeList,
-				MaxItems:    1,
 				Optional:    true,
-				Description: "When the provider is used for DNS updates, this block is required.",
+				Description: "When the provider is used for DNS updates, this block is required. Only one `update` block may be in the configuration.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"server": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_SERVER", nil),
-							Description: "The hostname or IP address of the DNS server to send updates to.",
+							Description: "The hostname or IP address of the DNS server to send updates to. " +
+								"Value can also be sourced from the DNS_UPDATE_SERVER environment variable.",
 						},
 						"port": {
 							Type:     schema.TypeInt,
@@ -53,7 +53,8 @@ func New() *schema.Provider {
 
 								return defaultPort, nil
 							},
-							Description: "The target UDP port on the server where updates are sent to. Defaults to `53`.",
+							Description: "The target UDP port on the server where updates are sent to. Defaults to `53`. " +
+								"Value can also be sourced from the DNS_UPDATE_PORT environment variable.",
 						},
 						"transport": {
 							Type:        schema.TypeString,
@@ -61,14 +62,16 @@ func New() *schema.Provider {
 							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_TRANSPORT", defaultTransport),
 							Description: "Transport to use for DNS queries. Valid values are `udp`, `udp4`, `udp6`, " +
 								"`tcp`, `tcp4`, or `tcp6`. Any UDP transport will retry automatically with the " +
-								"equivalent TCP transport in the event of a truncated response. Defaults to `udp`.",
+								"equivalent TCP transport in the event of a truncated response. Defaults to `udp`. " +
+								"Value can also be sourced from the DNS_UPDATE_TRANSPORT environment variable.",
 						},
 						"timeout": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_TIMEOUT", defaultTimeout),
 							Description: "Timeout for DNS queries. Valid values are durations expressed as `500ms`, " +
-								"etc. or a plain number which is treated as whole seconds.",
+								"etc. or a plain number which is treated as whole seconds. " +
+								"Value can also be sourced from the DNS_UPDATE_TIMEOUT environment variable.",
 						},
 						"retries": {
 							Type:     schema.TypeInt,
@@ -84,38 +87,35 @@ func New() *schema.Provider {
 
 								return defaultRetries, nil
 							},
-							Description: "How many times to retry on connection timeout. Defaults to `3`.",
+							Description: "How many times to retry on connection timeout. Defaults to `3`. " +
+								"Value can also be sourced from the DNS_UPDATE_RETRIES environment variable.",
 						},
 						"key_name": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							DefaultFunc:   schema.EnvDefaultFunc("DNS_UPDATE_KEYNAME", nil),
-							ConflictsWith: []string{"update.0.gssapi.0"},
-							RequiredWith:  []string{"update.0.key_algorithm", "update.0.key_secret"},
-							Description:   "The name of the TSIG key used to sign the DNS update messages.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_KEYNAME", nil),
+							Description: "The name of the TSIG key used to sign the DNS update messages. " +
+								"Value can also be sourced from the DNS_UPDATE_KEYNAME environment variable.",
 						},
 						"key_algorithm": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							DefaultFunc:   schema.EnvDefaultFunc("DNS_UPDATE_KEYALGORITHM", nil),
-							ConflictsWith: []string{"update.0.gssapi.0"},
-							RequiredWith:  []string{"update.0.key_name", "update.0.key_secret"},
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_KEYALGORITHM", nil),
 							Description: "Required if `key_name` is set. When using TSIG authentication, the " +
 								"algorithm to use for HMAC. Valid values are `hmac-md5`, `hmac-sha1`, `hmac-sha256` " +
-								"or `hmac-sha512`.",
+								"or `hmac-sha512`. " +
+								"Value can also be sourced from the DNS_UPDATE_KEYALGORITHM environment variable.",
 						},
 						"key_secret": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							DefaultFunc:   schema.EnvDefaultFunc("DNS_UPDATE_KEYSECRET", nil),
-							ConflictsWith: []string{"update.0.gssapi.0"},
-							RequiredWith:  []string{"update.0.key_name", "update.0.key_algorithm"},
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_KEYSECRET", nil),
 							Description: "Required if `key_name` is set\nA Base64-encoded string containing the " +
-								"shared secret to be used for TSIG.",
+								"shared secret to be used for TSIG. " +
+								"Value can also be sourced from the DNS_UPDATE_KEYSECRET environment variable.",
 						},
 						"gssapi": {
 							Type:     schema.TypeList,
-							MaxItems: 1,
 							Optional: true,
 							Description: "A `gssapi` block. Only one `gssapi` block may be in the configuration. " +
 								"Conflicts with use of `key_name`, `key_algorithm` and `key_secret`.",
@@ -123,40 +123,39 @@ func New() *schema.Provider {
 								Schema: map[string]*schema.Schema{
 									"realm": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
 										DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_REALM", nil),
-										Description: "The Kerberos realm or Active Directory domain.",
+										Description: "The Kerberos realm or Active Directory domain. " +
+											"Value can also be sourced from the DNS_UPDATE_REALM environment variable.",
 									},
 									"username": {
 										Type:        schema.TypeString,
 										Optional:    true,
 										DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_USERNAME", nil),
 										Description: "The name of the user to authenticate as. If not set the current " +
-											"user session will be used.",
+											"user session will be used. " +
+											"Value can also be sourced from the DNS_UPDATE_USERNAME environment variable.",
 									},
 									"password": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										DefaultFunc:   schema.EnvDefaultFunc("DNS_UPDATE_PASSWORD", nil),
-										ConflictsWith: []string{"update.0.gssapi.0.keytab"},
-										RequiredWith:  []string{"update.0.gssapi.0.username"},
-										Sensitive:     true,
+										Type:        schema.TypeString,
+										Optional:    true,
+										DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_PASSWORD", nil),
+										Sensitive:   true,
 										Description: "This or `keytab` is required if `username` is set. The matching " +
-											"password for `username`.",
+											"password for `username`. " +
+											"Value can also be sourced from the DNS_UPDATE_PASSWORD environment variable.",
 									},
 									"keytab": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										DefaultFunc:   schema.EnvDefaultFunc("DNS_UPDATE_KEYTAB", nil),
-										ConflictsWith: []string{"update.0.gssapi.0.password"},
-										RequiredWith:  []string{"update.0.gssapi.0.username"},
+										Type:        schema.TypeString,
+										Optional:    true,
+										DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_KEYTAB", nil),
 										Description: "This or `password` is required if `username` is set, not " +
 											"supported on Windows. The path to a keytab file containing a key for " +
-											"`username`.",
+											"`username`. " +
+											"Value can also be sourced from the DNS_UPDATE_KEYTAB environment variable.",
 									},
 								},
 							},
-							ConflictsWith: []string{"update.0.key_name", "update.0.key_algorithm", "update.0.key_secret"},
 						},
 					},
 				},

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -37,34 +37,37 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Blocks: map[string]schema.Block{
 			"update": schema.ListNestedBlock{
-				Description: "When the provider is used for DNS updates, this block is required.",
+				Description: "When the provider is used for DNS updates, this block is required. Only one `update` block may be in the configuration.",
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"server": schema.StringAttribute{
-							Required:    true,
-							Description: "The hostname or IP address of the DNS server to send updates to.",
+							Optional:    true,
+							Description: "The hostname or IP address of the DNS server to send updates to. Value can also be sourced from the DNS_UPDATE_SERVER environment variable.",
 						},
 						"port": schema.Int64Attribute{
 							Optional:    true,
-							Description: "The target UDP port on the server where updates are sent to. Defaults to `53`.",
+							Description: "The target UDP port on the server where updates are sent to. Defaults to `53`. Value can also be sourced from the DNS_UPDATE_PORT environment variable.",
 						},
 						"transport": schema.StringAttribute{
 							Optional: true,
 							Description: "Transport to use for DNS queries. Valid values are `udp`, `udp4`, `udp6`, " +
 								"`tcp`, `tcp4`, or `tcp6`. Any UDP transport will retry automatically with the " +
-								"equivalent TCP transport in the event of a truncated response. Defaults to `udp`.",
+								"equivalent TCP transport in the event of a truncated response. Defaults to `udp`. " +
+								"Value can also be sourced from the DNS_UPDATE_TRANSPORT environment variable.",
 						},
 						"timeout": schema.StringAttribute{
 							Optional: true,
 							Description: "Timeout for DNS queries. Valid values are durations expressed as `500ms`, " +
-								"etc. or a plain number which is treated as whole seconds.",
+								"etc. or a plain number which is treated as whole seconds. " +
+								"Value can also be sourced from the DNS_UPDATE_TIMEOUT environment variable.",
 						},
 						"retries": schema.Int64Attribute{
-							Optional:    true,
-							Description: "How many times to retry on connection timeout. Defaults to `3`.",
+							Optional: true,
+							Description: "How many times to retry on connection timeout. Defaults to `3`. " +
+								"Value can also be sourced from the DNS_UPDATE_RETRIES environment variable.",
 						},
 						"key_name": schema.StringAttribute{
 							Optional: true,
@@ -75,7 +78,8 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 									path.MatchRelative().AtParent().AtName("key_secret"),
 								),
 							},
-							Description: "The name of the TSIG key used to sign the DNS update messages.",
+							Description: "The name of the TSIG key used to sign the DNS update messages. " +
+								"Value can also be sourced from the DNS_UPDATE_KEYNAME environment variable.",
 						},
 						"key_algorithm": schema.StringAttribute{
 							Optional: true,
@@ -88,7 +92,7 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 							},
 							Description: "Required if `key_name` is set. When using TSIG authentication, the " +
 								"algorithm to use for HMAC. Valid values are `hmac-md5`, `hmac-sha1`, `hmac-sha256` " +
-								"or `hmac-sha512`.",
+								"or `hmac-sha512`. Value can also be sourced from the DNS_UPDATE_KEYALGORITHM environment variable.",
 						},
 						"key_secret": schema.StringAttribute{
 							Optional: true,
@@ -100,7 +104,7 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 								),
 							},
 							Description: "Required if `key_name` is set\nA Base64-encoded string containing the " +
-								"shared secret to be used for TSIG.",
+								"shared secret to be used for TSIG. Value can also be sourced from the DNS_UPDATE_KEYSECRET environment variable.",
 						},
 					},
 					Blocks: map[string]schema.Block{
@@ -118,13 +122,13 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"realm": schema.StringAttribute{
-										Required:    true,
-										Description: "The Kerberos realm or Active Directory domain.",
+										Optional:    true,
+										Description: "The Kerberos realm or Active Directory domain. Value can also be sourced from the DNS_UPDATE_REALM environment variable.",
 									},
 									"username": schema.StringAttribute{
 										Optional: true,
 										Description: "The name of the user to authenticate as. If not set the current " +
-											"user session will be used.",
+											"user session will be used. Value can also be sourced from the DNS_UPDATE_USERNAME environment variable.",
 									},
 									"password": schema.StringAttribute{
 										Optional: true,
@@ -134,7 +138,7 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 										},
 										Sensitive: true,
 										Description: "This or `keytab` is required if `username` is set. The matching " +
-											"password for `username`.",
+											"password for `username`. Value can also be sourced from the DNS_UPDATE_PASSWORD environment variable.",
 									},
 									"keytab": schema.StringAttribute{
 										Optional: true,
@@ -144,7 +148,7 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 										},
 										Description: "This or `password` is required if `username` is set, not " +
 											"supported on Windows. The path to a keytab file containing a key for " +
-											"`username`.",
+											"`username`. Value can also be sourced from the DNS_UPDATE_KEYTAB environment variable.",
 									},
 								},
 							},


### PR DESCRIPTION
Closes #293

Using terraform-plugin-mux requires the provider schemas of all underlying provider implementations to exactly match to prevent confusing behavior. One legacy quirk of terraform-plugin-sdk was that it allows an attribute to be marked in a schema as required, but also support optional configuration via a default. This confusing definition of configuration requirement is no longer supported in terraform-plugin-framework.

This changeset includes the following:

- Adjusts the provider acceptance testing to always use mux server (except for the two remaining sdk resources), similar to the production binary.
- Adjusts the provider schema definitions to always use optional when the configuration value may be sourced from environment variable.
- Adjusts the provider schema descriptions to call out the associated environment variable name for configuration.
- Adjusts the provider schema validations to only be handled by terraform-plugin-framework to prevent confusing or duplicate diagnostics

Using https://github.com/hashicorp/terraform-plugin-mux/pull/153 to workaround an upstream terraform-plugin-mux issue, the following acceptance test failure was observable:

```
=== RUN   TestAccProvider_Update_Server_Env
    provider_test.go:166: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: failed to read schema for data.dns_a_record_set.test in registry.terraform.io/hashicorp/dns: failed to retrieve schema from provider "registry.terraform.io/hashicorp/dns": Invalid Provider Server Combination: The combined provider has differing provider schema implementations across providers. Provider schemas must be identical across providers. This is always an issue in the provider implementation and should be reported to the provider developers.

        Provider schema difference:   &tfprotov5.Schema{
                Version: 0,
                Block: &tfprotov5.SchemaBlock{
                        Version:    0,
                        Attributes: nil,
                        BlockTypes: []*tfprotov5.SchemaNestedBlock{
                                &{
                                        TypeName: "update",
                                        Block: &tfprotov5.SchemaBlock{
                                                Version: 0,
                                                Attributes: []*tfprotov5.SchemaAttribute{
                                                        ... // 3 identical elements
                                                        &{Name: "port", Type: s"tftypes.Number", Description: "The target UDP port on the server where updates are sent to. Def"..., Optional: true, ...},
                                                        &{Name: "retries", Type: s"tftypes.Number", Description: "How many times to retry on connection timeout. Defaults to `3`.", Optional: true, ...},
                                                        &{
                                                                Name:        "server",
                                                                Type:        s"tftypes.String",
                                                                Description: "The hostname or IP address of the DNS server to send updates to.",
        -                                                       Required:    false,
        +                                                       Required:    true,
        -                                                       Optional:    true,
        +                                                       Optional:    false,
                                                                Computed:    false,
                                                                Sensitive:   false,
                                                                ... // 2 identical fields
                                                        },
                                                        &{Name: "timeout", Type: s"tftypes.String", Description: "Timeout for DNS queries. Valid values are durations expressed as"..., Optional: true, ...},
                                                        &{Name: "transport", Type: s"tftypes.String", Description: "Transport to use for DNS queries. Valid values are `udp`, `udp4`"..., Optional: true, ...},
                                                },
                                                BlockTypes:  {&{TypeName: "gssapi", Block: &{Attributes: {&{Name: "keytab", Type: s"tftypes.String", Description: "This or `password` is required if `username` is set, not support"..., Optional: true, ...}, &{Name: "password", Type: s"tftypes.String", Description: "This or `keytab` is required if `username` is set. The matching "..., Optional: true, ...}, &{Name: "realm", Type: s"tftypes.String", Description: "The Kerberos realm or Active Directory domain.", Required: true, ...}, &{Name: "username", Type: s"tftypes.String", Description: "The name of the user to authenticate as. If not set the current "..., Optional: true, ...}}, Description: "A `gssapi` block. Only one `gssapi` block may be in the configur"...}, Nesting: s"LIST"}},
                                                Description: "When the provider is used for DNS updates, this block is required.",
                                                ... // 2 identical fields
                                        },
                                        Nesting: s"LIST",
                                        ... // 2 ignored fields
                                },
                        },
                        Description:     "",
                        DescriptionKind: s"PLAIN",
                        Deprecated:      false,
                },
          }

--- FAIL: TestAccProvider_Update_Server_Env (0.38s)
```

Similarly, the same issue could occur with the realm:

```
=== RUN   TestAccProvider_Update_Server_Env
    provider_test.go:166: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: failed to read schema for data.dns_a_record_set.test in registry.terraform.io/hashicorp/dns: failed to retrieve schema from provider "registry.terraform.io/hashicorp/dns": Invalid Provider Server Combination: The combined provider has differing provider schema implementations across providers. Provider schemas must be identical across providers. This is always an issue in the provider implementation and should be reported to the provider developers.

        Provider schema difference:   &tfprotov5.Schema{
                Version: 0,
                Block: &tfprotov5.SchemaBlock{
                        Version:    0,
                        Attributes: nil,
                        BlockTypes: []*tfprotov5.SchemaNestedBlock{
                                &{
                                        TypeName: "update",
                                        Block: &tfprotov5.SchemaBlock{
                                                Version:    0,
                                                Attributes: {&{Name: "key_algorithm", Type: s"tftypes.String", Description: "Required if `key_name` is set. When using TSIG authentication, t"..., Optional: true, ...}, &{Name: "key_name", Type: s"tftypes.String", Description: "The name of the TSIG key used to sign the DNS update messages.", Optional: true, ...}, &{Name: "key_secret", Type: s"tftypes.String", Description: "Required if `key_name` is set\nA Base64-encoded string containing"..., Optional: true, ...}, &{Name: "port", Type: s"tftypes.Number", Description: "The target UDP port on the server where updates are sent to. Def"..., Optional: true, ...}, ...},
                                                BlockTypes: []*tfprotov5.SchemaNestedBlock{
                                                        &{
                                                                TypeName: "gssapi",
                                                                Block: &tfprotov5.SchemaBlock{
                                                                        Version: 0,
                                                                        Attributes: []*tfprotov5.SchemaAttribute{
                                                                                &{Name: "keytab", Type: s"tftypes.String", Description: "This or `password` is required if `username` is set, not support"..., Optional: true, ...},
                                                                                &{Name: "password", Type: s"tftypes.String", Description: "This or `keytab` is required if `username` is set. The matching "..., Optional: true, ...},
                                                                                &{
                                                                                        Name:        "realm",
                                                                                        Type:        s"tftypes.String",
                                                                                        Description: "The Kerberos realm or Active Directory domain.",
        -                                                                               Required:    false,
        +                                                                               Required:    true,
        -                                                                               Optional:    true,
        +                                                                               Optional:    false,
                                                                                        Computed:    false,
                                                                                        Sensitive:   false,
                                                                                        ... // 2 identical fields
                                                                                },
                                                                                &{Name: "username", Type: s"tftypes.String", Description: "The name of the user to authenticate as. If not set the current "..., Optional: true, ...},
                                                                        },
                                                                        BlockTypes:  nil,
                                                                        Description: "A `gssapi` block. Only one `gssapi` block may be in the configur"...,
                                                                        ... // 2 identical fields
                                                                },
                                                                Nesting: s"LIST",
                                                                ... // 2 ignored fields
                                                        },
                                                },
                                                Description:     "When the provider is used for DNS updates, this block is required.",
                                                DescriptionKind: s"PLAIN",
                                                Deprecated:      false,
                                        },
                                        Nesting: s"LIST",
                                        ... // 2 ignored fields
                                },
                        },
                        Description:     "",
                        DescriptionKind: s"PLAIN",
                        Deprecated:      false,
                },
          }

--- FAIL: TestAccProvider_Update_Server_Env (0.12s)
```