### PR TITLE
internal/provider: Consolidate testing record removal logic

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -438,3 +438,30 @@ func initializeDNSClient(ctx context.Context) (*DNSClient, error) {
 
 	return dnsClient, nil
 }
+
+func testRemoveRecord(t *testing.T, recordType string, recordName string) {
+	msg := new(dns.Msg)
+	recordZone := "example.com."
+
+	msg.SetUpdate(recordZone)
+
+	rrStr := fmt.Sprintf("%s.%s 0 %s", recordName, recordZone, recordType)
+
+	rr, err := dns.NewRR(rrStr)
+
+	if err != nil {
+		t.Fatalf("Error generating DNS record (%s): %s", rrStr, err)
+	}
+
+	msg.RemoveRRset([]dns.RR{rr})
+
+	resp, err := exchange(msg, true, dnsClient)
+
+	if err != nil {
+		t.Fatalf("Error deleting DNS record (%s): %s", rrStr, err)
+	}
+
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("Error deleting DNS record (%s): %v", rrStr, resp.Rcode)
+	}
+}

--- a/internal/provider/resource_dns_aaaa_record_set_test.go
+++ b/internal/provider/resource_dns_aaaa_record_set_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,36 +12,6 @@ func TestAccDnsAAAARecordSet_basic(t *testing.T) {
 
 	resourceName := "dns_aaaa_record_set.bar"
 	resourceRoot := "dns_aaaa_record_set.root"
-
-	deleteAAAARecordSet := func() {
-		rec_name := "bar"
-		rec_zone := "example.com."
-
-		meta := testAccProvider.Meta()
-
-		msg := new(dns.Msg)
-
-		msg.SetUpdate(rec_zone)
-
-		rec_fqdn := testResourceFQDN(rec_name, rec_zone)
-
-		rrStr := fmt.Sprintf("%s 0 AAAA", rec_fqdn)
-
-		rr_remove, err := dns.NewRR(rrStr)
-		if err != nil {
-			t.Fatalf("Error reading DNS record (%s): %s", rrStr, err)
-		}
-
-		msg.RemoveRRset([]dns.RR{rr_remove})
-
-		r, err := exchange(msg, true, meta.(*DNSClient))
-		if err != nil {
-			t.Fatalf("Error deleting DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeSuccess {
-			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
-		}
-	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -66,7 +35,7 @@ func TestAccDnsAAAARecordSet_basic(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: deleteAAAARecordSet,
+				PreConfig: func() { testRemoveRecord(t, "AAAA", "bar") },
 				Config:    testAccDnsAAAARecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "addresses.#", "2"),

--- a/internal/provider/resource_dns_mx_record_set_test.go
+++ b/internal/provider/resource_dns_mx_record_set_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -35,7 +34,7 @@ func TestAccDnsMXRecordSet_Basic(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() { deleteMXRecordSet(t) },
+				PreConfig: func() { testRemoveRecord(t, "MX", "foo") },
 				Config:    testAccDnsMXRecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "mx.#", "2"),
@@ -108,7 +107,7 @@ func TestAccDnsMXRecordSet_Basic_Upgrade(t *testing.T) {
 			},
 			{
 				ExternalProviders: providerVersion324(),
-				PreConfig:         func() { deleteMXRecordSet(t) },
+				PreConfig:         func() { testRemoveRecord(t, "MX", "foo") },
 				Config:            testAccDnsMXRecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "mx.#", "2"),
@@ -127,34 +126,6 @@ func TestAccDnsMXRecordSet_Basic_Upgrade(t *testing.T) {
 			},
 		},
 	})
-}
-
-func deleteMXRecordSet(t *testing.T) {
-	name := "foo"
-	zone := "example.com."
-
-	msg := new(dns.Msg)
-
-	msg.SetUpdate(zone)
-
-	fqdn := testResourceFQDN(name, zone)
-
-	rrStr := fmt.Sprintf("%s 0 MX", fqdn)
-
-	rr_remove, err := dns.NewRR(rrStr)
-	if err != nil {
-		t.Fatalf("Error reading DNS record (%s): %s", rrStr, err)
-	}
-
-	msg.RemoveRRset([]dns.RR{rr_remove})
-
-	r, err := exchange(msg, true, dnsClient)
-	if err != nil {
-		t.Fatalf("Error deleting DNS record: %s", err)
-	}
-	if r.Rcode != dns.RcodeSuccess {
-		t.Fatalf("Error deleting DNS record: %v", r.Rcode)
-	}
 }
 
 func testAccCheckDnsMXRecordSetDestroy(s *terraform.State) error {


### PR DESCRIPTION
These functions all perform the same logic, just with differing record types and names.