### PR TITLE
internal/provider: Migrate rest of acceptance testing from ProviderFactories to ProtoV5ProviderFactories

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/miekg/dns"
 )
 
-var testAccProvider *schema.Provider
 var dnsClient *DNSClient
 var testProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
 	"dns": func() (tfprotov5.ProviderServer, error) {
@@ -40,7 +39,6 @@ func providerVersion324() map[string]resource.ExternalProvider {
 }
 
 func TestMain(m *testing.M) {
-	testAccProvider = New()
 	var clientErr error
 	dnsClient, clientErr = initializeDNSClient(context.Background())
 	if clientErr != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -30,12 +30,6 @@ var testProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, 
 	},
 }
 
-var testSDKProviderFactories = map[string]func() (*schema.Provider, error){
-	"dns": func() (*schema.Provider, error) {
-		return testAccProvider, nil
-	},
-}
-
 func providerVersion324() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"dns": {

--- a/internal/provider/resource_dns_a_record_set_test.go
+++ b/internal/provider/resource_dns_a_record_set_test.go
@@ -14,9 +14,9 @@ func TestAccDnsARecordSet_Basic(t *testing.T) {
 	resourceRoot := "dns_a_record_set.root"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testSDKProviderFactories,
-		CheckDestroy:      testAccCheckDnsARecordSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDnsARecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsARecordSet_basic,

--- a/internal/provider/resource_dns_aaaa_record_set_test.go
+++ b/internal/provider/resource_dns_aaaa_record_set_test.go
@@ -14,9 +14,9 @@ func TestAccDnsAAAARecordSet_basic(t *testing.T) {
 	resourceRoot := "dns_aaaa_record_set.root"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testSDKProviderFactories,
-		CheckDestroy:      testAccCheckDnsAAAARecordSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDnsAAAARecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsAAAARecordSet_basic,


### PR DESCRIPTION
Clearing out some queued code changes locally.

For consistency with the rest of the provider acceptance testing, the lingering terraform-plugin-sdk based resources can use the same testing setup as the terraform-plugin-framework based resources (which themselves all use the muxed provider for testing).