### PR TITLE
provider: Ensure timeout configuration value is parsed correctly

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230501-131218.yaml
+++ b/.changes/unreleased/BUG FIXES-20230501-131218.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'provider: Ensure timeout configuration value is parsed correctly'
+time: 2023-05-01T13:12:18.173441-04:00
+custom:
+  Issue: "298"

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -228,7 +228,7 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		}
 
 	} else {
-		timeout = providerUpdateConfig[0].Timeout.String()
+		timeout = providerUpdateConfig[0].Timeout.ValueString()
 	}
 
 	// Try parsing timeout as a duration
@@ -239,14 +239,16 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		var seconds int
 		seconds, err = strconv.Atoi(timeout)
 		if err != nil {
-			resp.Diagnostics.AddError("Invalid timeout:",
-				fmt.Sprintf("timeout cannot be parsed as an integer: %s", err.Error()))
+			resp.Diagnostics.AddError(
+				"Invalid DNS Provider Timeout Value",
+				fmt.Sprintf("Timeout cannot be parsed as an integer: %s", err.Error()),
+			)
 			return
 		}
 		duration = time.Duration(seconds) * time.Second
 	}
 	if duration < 0 {
-		resp.Diagnostics.AddError("Invalid timeout:", "timeout cannot be negative.")
+		resp.Diagnostics.AddError("Invalid timeout", "timeout cannot be negative.")
 		return
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -181,6 +181,52 @@ func TestAccProvider_Update_Server_Env(t *testing.T) {
 	})
 }
 
+func TestAccProvider_Update_Timeout_Config(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "dns" {
+					update {
+						timeout = 5
+					}
+				}
+
+				data "dns_a_record_set" "test" {
+					# Same host as data source testing
+					host = "terraform-provider-dns-a.hashicorptest.com"
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.dns_a_record_set.test", "addrs.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProvider_Update_Timeout_Env(t *testing.T) {
+	t.Setenv("DNS_UPDATE_TIMEOUT", "5")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				data "dns_a_record_set" "test" {
+					# Same host as data source testing
+					host = "terraform-provider-dns-a.hashicorptest.com"
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.dns_a_record_set.test", "addrs.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProvider_InvalidClientConfig(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testProtoV5ProviderFactories,


### PR DESCRIPTION
Closes #298

Previously:

```
--- FAIL: TestDnsProviderConfigure (0.00s)
    --- FAIL: TestDnsProviderConfigure/update-timeout-config-number (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/provider_framework_test.go:580: unexpected difference:   &provider.ConfigureResponse{
              	DataSourceData: nil,
            - 	Diagnostics: diag.Diagnostics{
            - 		diag.ErrorDiagnostic{
            - 			detail:  `Timeout cannot be parsed as an integer: strconv.Atoi: parsing "\`...,
            - 			summary: "Invalid DNS Provider timeout Value",
            - 		},
            - 	},
            + 	Diagnostics:  nil,
            - 	ResourceData: nil,
            + 	ResourceData: &provider.DNSClient{
            + 		c:         &dns.Client{Net: "udp", Timeout: s"5s"},
            + 		srv_addr:  ":53",
            + 		transport: "udp",
            + 		retries:   3,
            + 	},
              }
    --- FAIL: TestDnsProviderConfigure/update-timeout-config-and-env (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/provider_framework_test.go:580: unexpected difference:   &provider.ConfigureResponse{
              	DataSourceData: nil,
            - 	Diagnostics: diag.Diagnostics{
            - 		diag.ErrorDiagnostic{
            - 			detail:  `Timeout cannot be parsed as an integer: strconv.Atoi: parsing "\`...,
            - 			summary: "Invalid DNS Provider timeout Value",
            - 		},
            - 	},
            + 	Diagnostics:  nil,
            - 	ResourceData: nil,
            + 	ResourceData: &provider.DNSClient{
            + 		c:         &dns.Client{Net: "udp", Timeout: s"5s"},
            + 		srv_addr:  ":53",
            + 		transport: "udp",
            + 		retries:   3,
            + 	},
              }
    --- FAIL: TestDnsProviderConfigure/update-timeout-config-duration (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-provider-dns/internal/provider/provider_framework_test.go:580: unexpected difference:   &provider.ConfigureResponse{
              	DataSourceData: nil,
            - 	Diagnostics: diag.Diagnostics{
            - 		diag.ErrorDiagnostic{
            - 			detail:  `Timeout cannot be parsed as an integer: strconv.Atoi: parsing "\`...,
            - 			summary: "Invalid DNS Provider timeout Value",
            - 		},
            - 	},
            + 	Diagnostics:  nil,
            - 	ResourceData: nil,
            + 	ResourceData: &provider.DNSClient{
            + 		c:         &dns.Client{Net: "udp", Timeout: s"5s"},
            + 		srv_addr:  ":53",
            + 		transport: "udp",
            + 		retries:   3,
            + 	},
              }

=== CONT  TestAccProvider_Update_Timeout_Config
    provider_test.go:185: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid DNS Provider timeout Value

          with provider["registry.terraform.io/hashicorp/dns"],
          on terraform_plugin_test.tf line 2, in provider "dns":
           2:                           provider "dns" {

        Timeout cannot be parsed as an integer: strconv.Atoi: parsing "\"5\"":
        invalid syntax
--- FAIL: TestAccProvider_Update_Timeout_Config (1.21s)
FAIL
```