### PR TITLE
Add CNAME resolution tree (CNAME recursivity) to the dns_cname_record…

### DIFF
--- a/docs/data-sources/cname_record_set.md
+++ b/docs/data-sources/cname_record_set.md
@@ -33,3 +33,4 @@ output "hashi_cname" {
 
 - `cname` (String) A CNAME record associated with host.
 - `id` (String) Always set to the host.
+- `cname_tree` (List of String) All pieces of a CNAME tree recursively resolved.

--- a/internal/provider/data_dns_cname_record_set_test.go
+++ b/internal/provider/data_dns_cname_record_set_test.go
@@ -24,6 +24,30 @@ data "dns_cname_record_set" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "cname", "example.com."),
 					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-cname.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "cname_tree.0", "terraform-provider-dns-cname.hashicorptest.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataDnsCnameRecordSet_Advanced(t *testing.T) {
+	recordName := "data.dns_cname_record_set.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "dns_cname_record_set" "test" {
+  host = "test2.tony.docusign.dev"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(recordName, "cname", "stage.services.docusign.net."),
+					resource.TestCheckResourceAttr(recordName, "id", "test2.tony.docusign.dev"),
+					resource.TestCheckResourceAttr(recordName, "cname_tree.0", "test2.tony.docusign.dev"),
+					resource.TestCheckResourceAttr(recordName, "cname_tree.1", "stage.services.docusign.net."),
 				),
 			},
 		},


### PR DESCRIPTION
…_set datasource

It is actually hard to achieve recursivity with Terraform.
If at some time we want to follow a CNAME tree in Terraform it is near impossible to do it dynamically and find final leaf.

This feature would allow to get a CNAME full path to final leaf CNAME and allow to use those intermediate found elements to do some ops, here in Docusign, we need to know if one of those intermediate element cross a host that has "akadns.net." suffix (akamai global traffic management property) to add some controls to our Terraform GTM Automation.

I put one of our record to test, but we need to get a similar fixture record under hashicorptest.com and adapt the test for this.

Thx for your help/review/feedback