### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240910-073157.yaml
+++ b/.changes/unreleased/NOTES-20240910-073157.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: This release introduces no functional changes. It does however include
+  dependency updates which address upstream CVEs.'
+time: 2024-09-10T07:31:57.419866-04:00
+custom:
+  Issue: "476"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The DNS provider supports resources that perform DNS updates ([RFC 2136](https:/
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.21)
+* [Go](https://go.dev/doc/install) (1.22)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-provider-dns
 
-go 1.21
-
-toolchain go1.21.6
+go 1.22.7
 
 require (
 	github.com/bodgit/tsig v1.2.2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7