### PR TITLE
Prepare for 3.4.3 release

### DIFF
--- a/.changes/3.4.3.md
+++ b/.changes/3.4.3.md
@@ -1,0 +1,6 @@
+## 3.4.3 (April 29, 2025)
+
+NOTES:
+
+* Update dependencies ([#480](https://github.com/hashicorp/terraform-provider-dns/issues/480))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.3 (April 29, 2025)
+
+NOTES:
+
+* Update dependencies ([#480](https://github.com/hashicorp/terraform-provider-dns/issues/480))
+
 ## 3.4.2 (September 10, 2024)
 
 NOTES:


### PR DESCRIPTION
Prepares changelog for a `3.4.3` release with the new CRT migration process. The `version/VERSION` file was already set to that version via #545 (and #546)