### PR TITLE
feat: add ability to configure Recursion Desired (RD) bit for DNS read queries only

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ A Base64-encoded string containing the shared secret to be used for TSIG. Value 
 - `server` (String) The hostname or IP address of the DNS server to send updates to. Value can also be sourced from the DNS_UPDATE_SERVER environment variable.
 - `timeout` (String) Timeout for DNS queries. Valid values are durations expressed as `500ms`, etc. or a plain number which is treated as whole seconds. Value can also be sourced from the DNS_UPDATE_TIMEOUT environment variable.
 - `transport` (String) Transport to use for DNS queries. Valid values are `udp`, `udp4`, `udp6`, `tcp`, `tcp4`, or `tcp6`. Any UDP transport will retry automatically with the equivalent TCP transport in the event of a truncated response. Defaults to `udp`. Value can also be sourced from the DNS_UPDATE_TRANSPORT environment variable.
+- `recursive` (Boolean) Whether DNS resolution queries should be made recursively. When set to `true`, the DNS server is expected to perform full resolution and return a complete answer. When set to `false`, the server may return a referral to other name servers. Defaults to `false`. Value can also be sourced from the DNS_UPDATE_RECURSIVE environment variable.
 
 <a id="nestedblock--update--gssapi"></a>
 ### Nested Schema for `update.gssapi`

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	username  string
 	password  string
 	keytab    string
+	recursive bool
 }
 
 type DNSClient struct {
@@ -46,6 +47,7 @@ type DNSClient struct {
 	username  string
 	password  string
 	keytab    string
+	recursive bool
 }
 
 // Client configures and returns a fully initialized DNSClient.
@@ -75,6 +77,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	client.username = c.username
 	client.password = c.password
 	client.keytab = c.keytab
+	client.recursive = c.recursive
 	if !c.gssapi && c.keyname != "" {
 		if !dns.IsFqdn(c.keyname) {
 			return nil, fmt.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -71,6 +71,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 	t.Setenv("DNS_UPDATE_TRANSPORT", "")
 	t.Setenv("DNS_UPDATE_TIMEOUT", "")
 	t.Setenv("DNS_UPDATE_USERNAME", "")
+	t.Setenv("DNS_UPDATE_RECURSIVE", "")
 
 	testCases := map[string]struct {
 		env      map[string]string
@@ -112,6 +113,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -150,6 +152,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -224,6 +227,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -262,6 +266,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -317,6 +322,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringValue("5s"),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -353,6 +359,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringValue("5"),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -392,6 +399,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringValue("5"),
 									"transport":     types.StringNull(),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -489,6 +497,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringValue("tcp"),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -527,6 +536,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 									"retries":       types.Int64Null(),
 									"timeout":       types.StringNull(),
 									"transport":     types.StringValue("tcp"),
+									"recursive":     types.BoolNull(),
 								},
 							),
 						},
@@ -561,6 +571,104 @@ func TestDnsProviderConfigure(t *testing.T) {
 					retries:   3,
 					srv_addr:  ":53",
 					transport: "tcp",
+				},
+			},
+		},
+		"update-recursive-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.objectType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.objectAttributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+									"recursive":     types.BoolValue(true),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "udp",
+					recursive: true,
+				},
+			},
+		},
+		"update-recursive-config-and-env": {
+			env: map[string]string{
+				"DNS_UPDATE_RECURSIVE": "true",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListValueMust(
+						providerUpdateModel{}.objectType(),
+						[]attr.Value{
+							types.ObjectValueMust(
+								providerUpdateModel{}.objectAttributeTypes(),
+								map[string]attr.Value{
+									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
+									"key_name":      types.StringNull(),
+									"key_algorithm": types.StringNull(),
+									"key_secret":    types.StringNull(),
+									"port":          types.Int64Null(),
+									"server":        types.StringNull(),
+									"retries":       types.Int64Null(),
+									"timeout":       types.StringNull(),
+									"transport":     types.StringNull(),
+									"recursive":     types.BoolValue(false),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "udp",
+					recursive: false,
+				},
+			},
+		},
+		"update-recursive-env": {
+			env: map[string]string{
+				"DNS_UPDATE_RECURSIVE": "true",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "udp",
+					recursive: true,
 				},
 			},
 		},


### PR DESCRIPTION
This PR introduces a new configuration option: `recursive` (Boolean), which allows users to control whether the `Recursion Desired (RD) `bit is set for DNS read (resolution) queries.

**Purpose**

In our current architecture, DNS update requests are sent to an authoritative DNS server, while resolution (read) queries are sent to a recursive resolver. However, without this change, read queries are rejected by our recursive resolver because the Recursion Desired (RD) flag is set to 0 by default. Recursive resolvers expect this flag to be explicitly set to 1 in order to process and resolve the query.

By introducing the recursive configuration option, we allow users to control the RD bit for read queries only, ensuring compatibility with recursive resolvers and avoiding rejected requests.

This change increases flexibility for mixed DNS infrastructures where update and resolution paths differ.

**New setting**

The following configuration field has been added under the update block:

-  recursive (Boolean): Whether DNS resolution queries should be made recursively. When set to true, the DNS server is expected to perform full resolution and return a complete answer. When set to false, the server may return a referral to other name servers. Defaults to false. This value can also be sourced from the DNS_UPDATE_RECURSIVE environment variable.

**Additional Notes**

- [x] This setting only affects read queries, not dynamic updates.
- [x] No changes were made to the provider plugin behavior or logic unrelated to this flag.
- [x] Documentation has been updated accordingly.
- [x] Unit tests have been added to cover both recursive and non-recursive query behavior.