### PR TITLE
chore: Migrate live DNS records for acceptance test to new subdomain

### DIFF
--- a/internal/provider/data_dns_a_record_set_test.go
+++ b/internal/provider/data_dns_a_record_set_test.go
@@ -18,13 +18,13 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_a_record_set" "test" {
-  host = "terraform-provider-dns-a.hashicorptest.com"
+  host = "a.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "addrs.#", "1"),
 					resource.TestCheckTypeSetElemAttr(recordName, "addrs.*", "127.0.0.1"),
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-a.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "a.dns.tfacc.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_aaaa_record_set_test.go
+++ b/internal/provider/data_dns_aaaa_record_set_test.go
@@ -18,13 +18,13 @@ func TestAccDataDnsAAAARecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_aaaa_record_set" "test" {
-  host = "terraform-provider-dns-aaaa.hashicorptest.com"
+  host = "aaaa.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "addrs.#", "1"),
 					resource.TestCheckTypeSetElemAttr(recordName, "addrs.*", "::1"),
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-aaaa.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "aaaa.dns.tfacc.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_cname_record_set_test.go
+++ b/internal/provider/data_dns_cname_record_set_test.go
@@ -18,12 +18,12 @@ func TestAccDataDnsCnameRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_cname_record_set" "test" {
-  host = "terraform-provider-dns-cname.hashicorptest.com"
+  host = "cname.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recordName, "cname", "example.com."),
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-cname.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "cname.dns.tfacc.hashicorptest.com"),
 				),
 			},
 		},

--- a/internal/provider/data_dns_mx_record_set_test.go
+++ b/internal/provider/data_dns_mx_record_set_test.go
@@ -18,11 +18,11 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_mx_record_set" "test" {
-  domain = "terraform-provider-dns-mx.hashicorptest.com"
+  domain = "mx.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-mx.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "mx.dns.tfacc.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "mx.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(recordName, "mx.*", map[string]string{
 						"exchange":   "example.com.",

--- a/internal/provider/data_dns_ns_record_set_test.go
+++ b/internal/provider/data_dns_ns_record_set_test.go
@@ -18,16 +18,16 @@ func TestAccDataDnsNSRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_ns_record_set" "test" {
-  host = "terraform-provider-dns-ns.hashicorptest.com"
+  host = "ns.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-ns.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "ns.dns.tfacc.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "nameservers.#", "4"),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-1407.awsdns-47.org."),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-1816.awsdns-35.co.uk."),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-307.awsdns-38.com."),
-					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-655.awsdns-17.net."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-1172.awsdns-18.org."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-1747.awsdns-26.co.uk."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-67.awsdns-08.com."),
+					resource.TestCheckTypeSetElemAttr(recordName, "nameservers.*", "ns-555.awsdns-05.net."),
 				),
 			},
 		},

--- a/internal/provider/data_dns_srv_record_set_test.go
+++ b/internal/provider/data_dns_srv_record_set_test.go
@@ -18,11 +18,11 @@ func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_srv_record_set" "test" {
-  service = "_sip._tls.hashicorptest.com"
+  service = "_sip._tls.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "_sip._tls.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "_sip._tls.dns.tfacc.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "srv.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(recordName, "srv.*", map[string]string{
 						"port":     "443",

--- a/internal/provider/data_dns_txt_record_set_test.go
+++ b/internal/provider/data_dns_txt_record_set_test.go
@@ -19,11 +19,11 @@ func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
 			{
 				Config: `
 data "dns_txt_record_set" "test" {
-  host = "terraform-provider-dns-txt.hashicorptest.com"
+  host = "txt.dns.tfacc.hashicorptest.com"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(recordName, "id", "terraform-provider-dns-txt.hashicorptest.com"),
+					resource.TestCheckResourceAttr(recordName, "id", "txt.dns.tfacc.hashicorptest.com"),
 					resource.TestCheckResourceAttr(recordName, "record", "v=spf1 -all"),
 					resource.TestCheckResourceAttr(recordName, "records.#", "1"),
 					resource.TestCheckTypeSetElemAttr(recordName, "records.*", "v=spf1 -all"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -119,7 +119,7 @@ func TestAccProvider_Update_Gssapi_Realm(t *testing.T) {
 
 				data "dns_a_record_set" "test" {
 					# Same host as data source testing
-					host = "terraform-provider-dns-a.hashicorptest.com"
+					host = "a.dns.tfacc.hashicorptest.com"
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -144,7 +144,7 @@ func TestAccProvider_Update_Server_Config(t *testing.T) {
 
 				data "dns_a_record_set" "test" {
 					# Same host as data source testing
-					host = "terraform-provider-dns-a.hashicorptest.com"
+					host = "a.dns.tfacc.hashicorptest.com"
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -165,7 +165,7 @@ func TestAccProvider_Update_Server_Env(t *testing.T) {
 				Config: `
 				data "dns_a_record_set" "test" {
 					# Same host as data source testing
-					host = "terraform-provider-dns-a.hashicorptest.com"
+					host = "a.dns.tfacc.hashicorptest.com"
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -190,7 +190,7 @@ func TestAccProvider_Update_Timeout_Config(t *testing.T) {
 
 				data "dns_a_record_set" "test" {
 					# Same host as data source testing
-					host = "terraform-provider-dns-a.hashicorptest.com"
+					host = "a.dns.tfacc.hashicorptest.com"
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -211,7 +211,7 @@ func TestAccProvider_Update_Timeout_Env(t *testing.T) {
 				Config: `
 				data "dns_a_record_set" "test" {
 					# Same host as data source testing
-					host = "terraform-provider-dns-a.hashicorptest.com"
+					host = "a.dns.tfacc.hashicorptest.com"
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
Migrate live DNS records from `terraform-provider-dns-<type>.hashicorptest.com` pattern to `<type>.dns.tfacc.hashicorptest.com` to better isolate the test records and align with other usages of the `hashicorptest.com` domain.

## Related Issue



## Description

Move the Terraform DNS Provider's live test records to their own subdomain off of [hashicorptest.com](http://hashicorptest.com/)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No
