### PR TITLE
fix(data-source): resolve non-deterministic CNAME chain results

### DIFF
--- a/.changes/unreleased/BUG FIXES-615.yaml
+++ b/.changes/unreleased/BUG FIXES-615.yaml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: 'data-source/dns_cname_record_set: Fix non-deterministic results for CNAME chain domains by querying for the direct CNAME target instead of following the entire chain'
+custom:
+  Issue: 615

--- a/internal/provider/data_dns_cname_record_set.go
+++ b/internal/provider/data_dns_cname_record_set.go
@@ -6,11 +6,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/miekg/dns"
 )
 
 var (
@@ -56,7 +56,8 @@ func (d *dnsCNAMERecordSetDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	host := config.Host.ValueString()
-	cname, err := net.LookupCNAME(host)
+	fqdn := dns.Fqdn(host)
+	cname, err := lookupCNAME(fqdn)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("error looking up CNAME records for %q: ", host), err.Error())
 		return

--- a/internal/provider/lookup.go
+++ b/internal/provider/lookup.go
@@ -3,7 +3,65 @@
 
 package provider
 
-import "net"
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+func getSystemResolver() (string, error) {
+	var addr string
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			addr = address
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, address)
+		},
+	}
+	// Trigger a DNS query to capture the system resolver address via the Dial hook.
+	// "." (root zone) is used because /etc/hosts entries (e.g. "localhost") are
+	// resolved without calling Dial. The query result itself is irrelevant.
+	r.LookupHost(context.Background(), ".") //nolint:errcheck
+	if addr == "" {
+		return "", fmt.Errorf("could not determine system DNS resolver")
+	}
+	return addr, nil
+}
+
+func extractCNAME(answers []dns.RR, fqdn string) (string, error) {
+	for _, ans := range answers {
+		if cname, ok := ans.(*dns.CNAME); ok {
+			if dns.Fqdn(cname.Hdr.Name) == fqdn {
+				return cname.Target, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no CNAME record found for %s", fqdn)
+}
+
+func lookupCNAME(fqdn string) (string, error) {
+	serverAddr, err := getSystemResolver()
+	if err != nil {
+		return "", err
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(fqdn, dns.TypeCNAME)
+	msg.RecursionDesired = true
+
+	client := new(dns.Client)
+	r, _, err := client.Exchange(msg, serverAddr)
+	if err != nil {
+		return "", fmt.Errorf("DNS query failed: %s", err)
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		return "", fmt.Errorf("DNS query returned %s", dns.RcodeToString[r.Rcode])
+	}
+	return extractCNAME(r.Answer, fqdn)
+}
 
 func lookupIP(host string) ([]string, []string, error) {
 	records, err := net.LookupIP(host)

--- a/internal/provider/lookup_test.go
+++ b/internal/provider/lookup_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestExtractCNAME_SingleRecord(t *testing.T) {
+	fqdn := "example.com."
+	answers := []dns.RR{
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "target.example.com.",
+		},
+	}
+
+	got, err := extractCNAME(answers, fqdn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "target.example.com." {
+		t.Errorf("got %q, want %q", got, "target.example.com.")
+	}
+}
+
+func TestExtractCNAME_Chain(t *testing.T) {
+	fqdn := "a.example.com."
+	// Simulate a CNAME chain: a -> b -> c
+	// A recursive resolver may return all chain entries in the answer section.
+	answers := []dns.RR{
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "a.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "b.example.com.",
+		},
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "b.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "c.example.com.",
+		},
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "c.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "d.example.com.",
+		},
+	}
+
+	got, err := extractCNAME(answers, fqdn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return only the direct target for the queried FQDN, not the final chain target.
+	if got != "b.example.com." {
+		t.Errorf("got %q, want %q", got, "b.example.com.")
+	}
+}
+
+func TestExtractCNAME_NoMatch(t *testing.T) {
+	fqdn := "notfound.example.com."
+	answers := []dns.RR{
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "other.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "target.example.com.",
+		},
+	}
+
+	_, err := extractCNAME(answers, fqdn)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExtractCNAME_EmptyAnswers(t *testing.T) {
+	fqdn := "example.com."
+	answers := []dns.RR{}
+
+	_, err := extractCNAME(answers, fqdn)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #615

`data "dns_cname_record_set"` returns non-deterministic results for domains with CNAME chains (e.g. `captive.apple.com`). This is because `net.LookupCNAME()` follows the entire CNAME chain and may return different entries from the chain on each invocation.

This PR replaces `net.LookupCNAME()` with a direct `dns.TypeCNAME` query using `miekg/dns` (already a project dependency). The answer section is filtered by owner name to return only the immediate CNAME target for the queried hostname, ensuring deterministic results regardless of chain length.

The system DNS resolver address is discovered via Go's `net.Resolver` `Dial` hook, so no provider configuration (`update {}` block) is required — preserving backward compatibility.

## Changes

- `internal/provider/lookup.go` — Added `getSystemResolver()`, `extractCNAME()`, and `lookupCNAME()` helper functions
- `internal/provider/data_dns_cname_record_set.go` — Replaced `net.LookupCNAME(host)` with `lookupCNAME(dns.Fqdn(host))`
- `internal/provider/lookup_test.go` — Unit tests for `extractCNAME` (single record, chain, no match, empty answers)
- `.changes/unreleased/BUG FIXES-615.yaml` — Changelog entry

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] New unit tests pass (`TestExtractCNAME_*`)
- [x] Existing acceptance test passes (`TestAccDataDnsCnameRecordSet_Basic`)
- [x] Full test suite passes (`go test -v -cover -timeout=120s -parallel=4 ./...`)
- [x] License headers verified via `copywrite headers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)