### PR TITLE
Allow fetching the Additional section instead of the Question section

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260525-145200.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260525-145200.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'resource/dns_a_record_set: Allow fetching the Additional section instead of the Question section'
+time: 2026-05-25T14:52:00.872442225+02:00
+custom:
+    Issue: "167"

--- a/.changes/unreleased/ENHANCEMENTS-20260525-145234.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260525-145234.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'resource/dns_aaaa_record_set: Allow fetching the Additional section instead of the Question section'
+time: 2026-05-25T14:52:34.640602081+02:00
+custom:
+    Issue: "167"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -667,11 +667,23 @@ func resourceDnsRead(d *schema.ResourceData, meta interface{}, rrType uint16) ([
 		if err != nil {
 			return nil, diag.Errorf("Error querying DNS record: %s", err)
 		}
+
+		// Read the Additional section instead of the Question section
+		useAdditional := false
+		if v, ok := d.GetOk("use_additional"); ok {
+			useAdditional = v.(bool)
+		}
+
 		switch r.Rcode {
 		case dns.RcodeSuccess:
 			// NS records are returned slightly differently
 			if (rrType == dns.TypeNS && len(r.Ns) > 0) || len(r.Answer) > 0 {
 				break
+			}
+			if useAdditional {
+				if len(r.Extra) > 0 {
+					break
+				}
 			}
 			fallthrough
 		case dns.RcodeNameError:
@@ -682,6 +694,21 @@ func resourceDnsRead(d *schema.ResourceData, meta interface{}, rrType uint16) ([
 
 		if rrType == dns.TypeNS {
 			return r.Ns, nil
+		}
+		// Only return from the Additional section rrType records
+		if useAdditional {
+			extractRR := make([]dns.RR, 0, len(r.Extra))
+
+			for _, rr := range r.Extra {
+				if rr == nil || rr.Header() == nil {
+					continue
+				}
+
+				if rr.Header().Rrtype == rrType {
+					extractRR = append(extractRR, rr)
+				}
+			}
+			return extractRR, nil
 		}
 		return r.Answer, nil
 	} else {

--- a/internal/provider/resource_dns_a_record_set.go
+++ b/internal/provider/resource_dns_a_record_set.go
@@ -54,6 +54,13 @@ func resourceDnsARecordSet() *schema.Resource {
 				Default:     3600,
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
+			"use_additional": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Validate record presence using only the Additional section. " + 
+					"Especially useful for glue records. Defaults to `false`.",
+			},
 		},
 
 		Description: "Creates an A type DNS record set.",

--- a/internal/provider/resource_dns_aaaa_record_set.go
+++ b/internal/provider/resource_dns_aaaa_record_set.go
@@ -54,6 +54,13 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 				Default:     3600,
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
+			"use_additional": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Validate record presence using only the Additional section. " + 
+					"Especially useful for glue records. Defaults to `false`.",
+			},
 		},
 
 		Description: "Creates an AAAA type DNS record set.",


### PR DESCRIPTION
## Related Issue

Fixes #167 

## Description

Glue records are not present in the `question` section but in the `additional` section. The resources `dns_a_record_set` and `dns_aaaa_record_set` fail because the read operation only uses the `question` section.
As described in the issue #167 , workaround are possible but not very clean.

The proposed solution is adding a new optional argument to  `dns_a_record_set` and `dns_aaaa_record_set` named `use_additional` which changes the read section from `question` to `additional`. Moreover, when reading the `additional` section, only records of the matching type are returned, as this section may contain a mix of different record types. 