### PR TITLE
Reject malformed FQDN values

### DIFF
--- a/internal/validators/dnsvalidator/is_zone_name_valid.go
+++ b/internal/validators/dnsvalidator/is_zone_name_valid.go
@@ -47,6 +47,13 @@ func (validator dnsZoneNameValidator) ValidateString(ctx context.Context, req va
 			req.ConfigValue.ValueString(),
 		))
 	}
+	if _, ok := dns.IsDomainName(value); !ok {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
+			req.Path,
+			"DNS zone name must be a valid domain name",
+			req.ConfigValue.ValueString(),
+		))
+	}
 }
 
 // IsZoneNameValid returns an AttributeValidator which ensures that any configured

--- a/internal/validators/dnsvalidator/is_zone_name_valid_test.go
+++ b/internal/validators/dnsvalidator/is_zone_name_valid_test.go
@@ -41,6 +41,14 @@ func TestIsZoneNameValid(t *testing.T) {
 			val:         types.StringValue(" example.com."),
 			expectError: true,
 		},
+		"string contains empty label": {
+			val:         types.StringValue("example..com."),
+			expectError: true,
+		},
+		"string contains double trailing dot": {
+			val:         types.StringValue("example.com.."),
+			expectError: true,
+		},
 		"string only whitespace": {
 			val:         types.StringValue(" "),
 			expectError: true,


### PR DESCRIPTION
## Summary
- Reject malformed fully qualified DNS names with empty labels in the shared zone-name validator.
- Cover both an interior empty label and the double trailing dot case from the CNAME crash report.

Closes #243

## Testing
- go test ./internal/validators/dnsvalidator -run TestIsZoneNameValid