### PR TITLE
Remove FQDN validation requirement for key_name to align with RFC 2845

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-192456.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-192456.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Remove FQDN validation requirement for key_name to align with RFC 2845
+time: 2026-07-27T19:24:56.24086+02:00
+custom:
+    Issue: "540"

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -79,9 +79,6 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	client.keytab = c.keytab
 	client.recursive = c.recursive
 	if !c.gssapi && c.keyname != "" {
-		if !dns.IsFqdn(c.keyname) {
-			return nil, fmt.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")
-		}
 		keyname := strings.ToLower(c.keyname)
 		client.keyname = keyname
 		client.keysecret = c.keysecret

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -104,6 +104,7 @@ func New() *schema.Provider {
 							Optional:    true,
 							DefaultFunc: schema.EnvDefaultFunc("DNS_UPDATE_KEYNAME", nil),
 							Description: "The name of the TSIG key used to sign the DNS update messages. " +
+								"The key name does not need to be a fully-qualified domain name. " +
 								"Value can also be sourced from the DNS_UPDATE_KEYNAME environment variable.",
 						},
 						"key_algorithm": {

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -22,6 +22,15 @@ func validateZone(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+func validateKeyName(v interface{}, k string) (ws []string, errors []error) {
+	//nolint:forcetypeassert
+	value := v.(string)
+	if strings.TrimSpace(value) == "" {
+		errors = append(errors, fmt.Errorf("DNS key name %q must not be empty: %q", k, value))
+	}
+	return
+}
+
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	//nolint:forcetypeassert
 	value := v.(string)

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -25,7 +25,7 @@ func validateZone(v interface{}, k string) (ws []string, errors []error) {
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	//nolint:forcetypeassert
 	value := v.(string)
-	if strings.TrimSpace(value) != value || len(value) == 0 {
+	if strings.TrimSpace(value) != value || strings.Contains(value, " ") || len(value) == 0 {
 		errors = append(errors, fmt.Errorf("DNS record name %q must not contain whitespace or be empty: %q", k, value))
 	}
 	if dns.IsFqdn(value) {

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -7,6 +7,32 @@ import (
 	"testing"
 )
 
+func TestValidateKeyName(t *testing.T) {
+	validNames := []string{
+		"mykey",
+		"update",
+		"mykey.example.com.",
+		"key.with.multiple.labels",
+	}
+	for _, v := range validNames {
+		_, errors := validateKeyName(v, "key_name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid key name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"",
+		" ",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateKeyName(v, "key_name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid key name", v)
+		}
+	}
+}
+
 func TestValidateZone(t *testing.T) {
 	validNames := []string{
 		"example.com.",

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -48,6 +48,8 @@ func TestValidateName(t *testing.T) {
 		" test. ",
 		" ",
 		"",
+		"test name",
+		"test  name",
 	}
 	for _, v := range invalidNames {
 		_, errors := validateName(v, "name")


### PR DESCRIPTION
Fixes #540
Fixes #175