### PR TITLE
Add mutex to serialize GSSAPI operations preventing gokrb5 context corruption

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-215.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-215.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Serialize GSSAPI operations with mutex to prevent concurrent gokrb5 context corruption
+time: 2026-07-27T19:35:00.000000+02:00
+custom:
+    Issue: "215"

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bodgit/tsig"
@@ -48,6 +49,7 @@ type DNSClient struct {
 	password  string
 	keytab    string
 	recursive bool
+	mu        sync.Mutex
 }
 
 // Client configures and returns a fully initialized DNSClient.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -483,6 +483,9 @@ func exchange(msg *dns.Msg, tsig bool, client *DNSClient) (*dns.Msg, error) {
 
 	// GSS-TSIG
 	if tsig && g != nil {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+
 		realm := client.realm
 		username := client.username
 		password := client.password


### PR DESCRIPTION
GSSAPI/TSIG updates against Windows DNS intermittently fail with `The message or signature supplied for verification has been altered` when multiple Terraform resources are processed in parallel. The root cause is thread-unsafe gokrb5 context usage.

This fix adds a `sync.Mutex` to the `DNSClient` struct and acquires it around GSSAPI operations in the `exchange` function, serializing all DNS operations that use GSSAPI to prevent concurrent context corruption.

Fixes #215