### PR TITLE
Fix CNAME data source to use direct DNS query (#171)

### DIFF
--- a/.changes/unreleased/171-cname-datasource-resolution.yml
+++ b/.changes/unreleased/171-cname-datasource-resolution.yml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: "dns_cname_record_set data source: use direct DNS query instead of net.LookupCNAME to avoid resolution failures when the CNAME target does not resolve"
+custom:
+  Issue: "171"

--- a/internal/provider/data_dns_cname_record_set.go
+++ b/internal/provider/data_dns_cname_record_set.go
@@ -6,22 +6,25 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/miekg/dns"
 )
 
 var (
-	_ datasource.DataSource = (*dnsCNAMERecordSetDataSource)(nil)
+	_ datasource.DataSource             = (*dnsCNAMERecordSetDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*dnsCNAMERecordSetDataSource)(nil)
 )
 
 func NewDnsCNAMERecordSetDataSource() datasource.DataSource {
 	return &dnsCNAMERecordSetDataSource{}
 }
 
-type dnsCNAMERecordSetDataSource struct{}
+type dnsCNAMERecordSetDataSource struct {
+	client *DNSClient
+}
 
 func (d *dnsCNAMERecordSetDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_cname_record_set"
@@ -47,6 +50,23 @@ func (d *dnsCNAMERecordSetDataSource) Schema(ctx context.Context, req datasource
 	}
 }
 
+func (d *dnsCNAMERecordSetDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*DNSClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *DNSClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
 func (d *dnsCNAMERecordSetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config cnameRecordSetConfig
 
@@ -56,9 +76,30 @@ func (d *dnsCNAMERecordSetDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	host := config.Host.ValueString()
-	cname, err := net.LookupCNAME(host)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(host), dns.TypeCNAME)
+	msg.RecursionDesired = d.client.recursive
+
+	r, err := exchange(msg, true, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("error looking up CNAME records for %q: ", host), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("error querying CNAME records for %q: ", host), err.Error())
+		return
+	}
+
+	if r.Rcode != dns.RcodeSuccess {
+		resp.Diagnostics.AddError(fmt.Sprintf("error looking up CNAME records for %q: ", host), fmt.Errorf("%v (%s)", r.Rcode, dns.RcodeToString[r.Rcode]).Error())
+		return
+	}
+
+	if len(r.Answer) == 0 {
+		resp.Diagnostics.AddError(fmt.Sprintf("no CNAME records found for %q", host), "")
+		return
+	}
+
+	cname, _, err := getCnameVal(r.Answer[0])
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("error parsing CNAME record for %q: ", host), err.Error())
 		return
 	}
 

--- a/internal/provider/data_dns_cname_record_set_test.go
+++ b/internal/provider/data_dns_cname_record_set_test.go
@@ -29,3 +29,21 @@ data "dns_cname_record_set" "test" {
 		},
 	})
 }
+
+func TestAccDataDnsCnameRecordSet_NonExistent(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "dns_cname_record_set" "test" {
+  host = "nonexistent.cname.dns.tfacc.hashicorptest.com"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.dns_cname_record_set.test", "cname", "target.example.com."),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Replace net.LookupCNAME with a direct miekg/dns query for CNAME records. The data source now uses the configured DNS client and queries for CNAME records directly instead of following the CNAME chain. This fixes failures when the CNAME target does not resolve.

Fixes #171