### PR TITLE
Allow subdomain names with dots in DNS record name validation (#296)

### DIFF
--- a/.changes/unreleased/296-cname-subdomain-records.yml
+++ b/.changes/unreleased/296-cname-subdomain-records.yml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: "dns_cname_record: allow subdomain names with dots to support CNAME records in subdomains of the zone"
+custom:
+  Issue: "296"

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -35,6 +35,8 @@ func TestValidateZone(t *testing.T) {
 func TestValidateName(t *testing.T) {
 	validNames := []string{
 		"test",
+		"alias.subdomain",
+		"host.subdomain.example",
 	}
 	for _, v := range validNames {
 		_, errors := validateName(v, "name")

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -58,3 +58,33 @@ func TestValidateName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateNameSubdomain(t *testing.T) {
+	validNames := []string{
+		"alias.subdomain",
+		"host.subdomain.example",
+		"a.b.c.d",
+		"my-host.subdomain",
+		"www",
+		"sub1.sub2.sub3.sub4",
+	}
+	for _, v := range validNames {
+		_, errors := validateName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid DNS record name with subdomains: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"alias.subdomain.",
+		" host.subdomain",
+		"",
+		" ",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid DNS record name", v)
+		}
+	}
+}

--- a/internal/validators/dnsvalidator/is_record_name_valid.go
+++ b/internal/validators/dnsvalidator/is_record_name_valid.go
@@ -19,7 +19,7 @@ type dnsRecordNameValidator struct {
 }
 
 func (validator dnsRecordNameValidator) Description(ctx context.Context) string {
-	return "value must be a fully qualified DNS record name"
+	return "value must not be a fully qualified DNS record name"
 }
 
 func (validator dnsRecordNameValidator) MarkdownDescription(ctx context.Context) string {

--- a/internal/validators/dnsvalidator/is_record_name_valid_test.go
+++ b/internal/validators/dnsvalidator/is_record_name_valid_test.go
@@ -49,6 +49,14 @@ func TestIsRecordNameValid(t *testing.T) {
 			val:         types.StringValue("test"),
 			expectError: false,
 		},
+		"name with dots (subdomain)": {
+			val:         types.StringValue("alias.subdomain"),
+			expectError: false,
+		},
+		"name with multiple subdomain levels": {
+			val:         types.StringValue("host.subdomain.example"),
+			expectError: false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The DNS record name validator now explicitly allows dots in record names, enabling users to set `name = "alias.subdomain"` to create CNAME records in subdomains of the zone (e.g., `alias.subdomain.example.com.`). Also fixes the `IsRecordNameValid` Description() which incorrectly stated the value must be fully qualified - it should reject FQDN names.

Fixes #296