### PR TITLE
Add retry loop for CNAME update read-back to handle propagation delay (#53)

### DIFF
--- a/.changes/unreleased/53-cname-record-update-race.yml
+++ b/.changes/unreleased/53-cname-record-update-race.yml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: "dns_cname_record: retry read-back after update to handle DNS propagation delay, preventing 'record differs' errors on first apply"
+custom:
+  Issue: "53"

--- a/internal/provider/resource_dns_cname_record.go
+++ b/internal/provider/resource_dns_cname_record.go
@@ -6,7 +6,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -263,10 +265,25 @@ func (d *dnsCNAMERecordResource) Update(ctx context.Context, req resource.Update
 		}
 	}
 
-	answers, diags := resourceDnsRead_framework(config, d.client, dns.TypeCNAME)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
+	updated := !plan.CNAME.Equal(state.CNAME)
+
+	var answers []dns.RR
+	var readDiags diag.Diagnostics
+
+	for attempts := 0; attempts < defaultRetries; attempts++ {
+		if attempts > 0 {
+			time.Sleep(1 * time.Second)
+		}
+
+		answers, readDiags = resourceDnsRead_framework(config, d.client, dns.TypeCNAME)
+		resp.Diagnostics.Append(readDiags...)
+		if readDiags.HasError() {
+			return
+		}
+
+		if len(answers) > 0 && (!updated || answers[0].(*dns.CNAME).Target == plan.CNAME.ValueString()) {
+			break
+		}
 	}
 
 	if len(answers) > 0 {

--- a/internal/provider/resource_dns_cname_record_test.go
+++ b/internal/provider/resource_dns_cname_record_test.go
@@ -127,3 +127,11 @@ var testAccDnsCnameRecord_update = `
     cname = "baz.example.com."
     ttl = 300
   }`
+
+func TestAccDnsCNAMERecord_RetryMechanism(t *testing.T) {
+	t.Skip("Retry mechanism requires DNS infrastructure with propagation delay to test")
+}
+
+func TestAccDnsCNAMERecord_RetryOnRead(t *testing.T) {
+	t.Skip("Retry mechanism test requires DNS infrastructure with propagation delay")
+}


### PR DESCRIPTION
After updating a CNAME record, the read-back verification can fail due to DNS propagation delay. This adds a retry loop (up to defaultRetries attempts) with a 1-second delay between attempts, waiting for the new record value to be visible before continuing.

Fixes #53