### PR TITLE
Filter DNS answers by requested record type to prevent wildcard CNAME interference (#90)

### DIFF
--- a/.changes/unreleased/90-wildcard-cname-a-record.yml
+++ b/.changes/unreleased/90-wildcard-cname-a-record.yml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: "resourceDnsRead: filter DNS answers to only include records of the requested type, preventing wildcard CNAME records from causing A record creation failures"
+custom:
+  Issue: "90"

--- a/internal/provider/data_dns_a_record_set_test.go
+++ b/internal/provider/data_dns_a_record_set_test.go
@@ -30,3 +30,7 @@ data "dns_a_record_set" "test" {
 		},
 	})
 }
+
+func TestAccDataDnsARecordSet_WildcardCNAME(t *testing.T) {
+	t.Skip("Requires DNS infrastructure with wildcard CNAME records")
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -683,7 +683,14 @@ func resourceDnsRead(d *schema.ResourceData, meta interface{}, rrType uint16) ([
 		if rrType == dns.TypeNS {
 			return r.Ns, nil
 		}
-		return r.Answer, nil
+
+		var filtered []dns.RR
+		for _, ans := range r.Answer {
+			if ans.Header().Rrtype == rrType {
+				filtered = append(filtered, ans)
+			}
+		}
+		return filtered, nil
 	} else {
 		return nil, diag.Errorf("update server is not set")
 	}

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -551,7 +551,14 @@ func resourceDnsRead_framework(config dnsConfig, client *DNSClient, rrType uint1
 	if rrType == dns.TypeNS {
 		return r.Ns, nil
 	}
-	return r.Answer, nil
+
+	var filtered []dns.RR
+	for _, ans := range r.Answer {
+		if ans.Header().Rrtype == rrType {
+			filtered = append(filtered, ans)
+		}
+	}
+	return filtered, nil
 }
 
 func resourceDnsDelete_framework(config dnsConfig, client *DNSClient, rrType uint16) diag.Diagnostics {


### PR DESCRIPTION
When a wildcard CNAME record matches a query for an A record, the DNS server returns the CNAME record in the answer section. The existing code returned all answers unfiltered, causing getAVal to fail with 'didn't get a A record' error.

This fix filters DNS answers in both `resourceDnsRead` (SDK v2) and `resourceDnsRead_framework` to only include records of the requested type. Wildcard CNAME records are now ignored and non-existent records are treated as such (returning empty).

Fixes #90