### PR TITLE
Fix crash: spaces in record names and Sscanf truncation in getter functions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-194006.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-194006.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'validators: reject record names containing spaces; provider: use struct fields directly in getter functions to avoid Sscanf truncation'
+time: 2026-07-27T19:40:06.808352+02:00
+custom:
+    Issue: "210"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -365,102 +365,52 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 
 func getAVal(record interface{}) (string, int, error) {
 
-	_, ok := record.(*dns.A)
+	a, ok := record.(*dns.A)
 	if !ok {
-		return "", 0, fmt.Errorf("didn't get a A record")
+		return "", 0, fmt.Errorf("didn't get an A record")
 	}
 
-	//nolint:forcetypeassert
-	recstr := record.(*dns.A).String()
-	var name, class, typ, addr string
-	var ttl int
-
-	_, err := fmt.Sscanf(recstr, "%s\t%d\t%s\t%s\t%s", &name, &ttl, &class, &typ, &addr)
-	if err != nil {
-		return "", 0, fmt.Errorf("Error parsing record: %s", err)
-	}
-
-	return addr, ttl, nil
+	return a.A.String(), int(a.Hdr.Ttl), nil
 }
 
 func getNSVal(record interface{}) (string, int, error) {
 
-	_, ok := record.(*dns.NS)
+	ns, ok := record.(*dns.NS)
 	if !ok {
-		return "", 0, fmt.Errorf("didn't get a NS record")
+		return "", 0, fmt.Errorf("didn't get an NS record")
 	}
 
-	//nolint:forcetypeassert
-	recstr := record.(*dns.NS).String()
-	var name, class, typ, nameserver string
-	var ttl int
-
-	_, err := fmt.Sscanf(recstr, "%s\t%d\t%s\t%s\t%s", &name, &ttl, &class, &typ, &nameserver)
-	if err != nil {
-		return "", 0, fmt.Errorf("Error parsing record: %s", err)
-	}
-
-	return nameserver, ttl, nil
+	return ns.Ns, int(ns.Hdr.Ttl), nil
 }
 
 func getAAAAVal(record interface{}) (string, int, error) {
 
-	_, ok := record.(*dns.AAAA)
+	a, ok := record.(*dns.AAAA)
 	if !ok {
-		return "", 0, fmt.Errorf("didn't get a AAAA record")
+		return "", 0, fmt.Errorf("didn't get an AAAA record")
 	}
 
-	//nolint:forcetypeassert
-	recstr := record.(*dns.AAAA).String()
-	var name, class, typ, addr string
-	var ttl int
-
-	_, err := fmt.Sscanf(recstr, "%s\t%d\t%s\t%s\t%s", &name, &ttl, &class, &typ, &addr)
-	if err != nil {
-		return "", 0, fmt.Errorf("Error parsing record: %s", err)
-	}
-
-	return addr, ttl, nil
+	return a.AAAA.String(), int(a.Hdr.Ttl), nil
 }
 
 func getCnameVal(record interface{}) (string, int, error) {
 
-	_, ok := record.(*dns.CNAME)
+	c, ok := record.(*dns.CNAME)
 	if !ok {
 		return "", 0, fmt.Errorf("didn't get a CNAME record")
 	}
 
-	//nolint:forcetypeassert
-	recstr := record.(*dns.CNAME).String()
-	var name, class, typ, cname string
-	var ttl int
-
-	_, err := fmt.Sscanf(recstr, "%s\t%d\t%s\t%s\t%s", &name, &ttl, &class, &typ, &cname)
-	if err != nil {
-		return "", 0, fmt.Errorf("Error parsing record: %s", err)
-	}
-
-	return cname, ttl, nil
+	return c.Target, int(c.Hdr.Ttl), nil
 }
 
 func getPtrVal(record interface{}) (string, int, error) {
 
-	_, ok := record.(*dns.PTR)
+	p, ok := record.(*dns.PTR)
 	if !ok {
 		return "", 0, fmt.Errorf("didn't get a PTR record")
 	}
 
-	//nolint:forcetypeassert
-	recstr := record.(*dns.PTR).String()
-	var name, class, typ, ptr string
-	var ttl int
-
-	_, err := fmt.Sscanf(recstr, "%s\t%d\t%s\t%s\t%s", &name, &ttl, &class, &typ, &ptr)
-	if err != nil {
-		return "", 0, fmt.Errorf("Error parsing record: %s", err)
-	}
-
-	return ptr, ttl, nil
+	return p.Ptr, int(p.Hdr.Ttl), nil
 }
 
 func isTimeout(err error) bool {

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -25,7 +25,7 @@ func validateZone(v interface{}, k string) (ws []string, errors []error) {
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	//nolint:forcetypeassert
 	value := v.(string)
-	if strings.TrimSpace(value) != value || len(value) == 0 {
+	if strings.TrimSpace(value) != value || strings.Contains(value, " ") || len(value) == 0 {
 		errors = append(errors, fmt.Errorf("DNS record name %q must not contain whitespace or be empty: %q", k, value))
 	}
 	if dns.IsFqdn(value) {

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -48,6 +48,8 @@ func TestValidateName(t *testing.T) {
 		" test. ",
 		" ",
 		"",
+		"test name",
+		"test  name",
 	}
 	for _, v := range invalidNames {
 		_, errors := validateName(v, "name")

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -5,6 +5,8 @@ package provider
 
 import (
 	"testing"
+
+	"github.com/miekg/dns"
 )
 
 func TestValidateZone(t *testing.T) {
@@ -56,5 +58,25 @@ func TestValidateName(t *testing.T) {
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid DNS record", v)
 		}
+	}
+}
+
+func TestGetPtrValNoTruncate(t *testing.T) {
+	target := "host.example.com."
+	ptr := &dns.PTR{
+		Ptr: target,
+		Hdr: dns.RR_Header{
+			Ttl: 3600,
+		},
+	}
+	result, ttl, err := getPtrVal(ptr)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if result != target {
+		t.Fatalf("expected %q, got %q", target, result)
+	}
+	if ttl != 3600 {
+		t.Fatalf("expected TTL 3600, got %d", ttl)
 	}
 }


### PR DESCRIPTION
Fixes #210