### PR TITLE
test: remove kinit dependency in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
+	github.com/jcmturner/gofork v1.7.6
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/miekg/dns v1.1.72
 )
 
@@ -45,9 +47,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
-	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
-	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/provider/acceptance.sh
+++ b/internal/provider/acceptance.sh
@@ -17,7 +17,7 @@ failed() {
 
 command -v docker >/dev/null 2>&1 || { echo >&2 "docker command not installed or in PATH"; exit 1; }
 command -v go >/dev/null 2>&1 || { echo >&2 "go command not installed or in PATH"; exit 1; }
-command -v kinit >/dev/null 2>&1 || { echo >&2 "kinit command not installed or in PATH"; exit 1; }
+go build -o /dev/null ./internal/provider/ccachehelper/ 2>/dev/null || { echo >&2 "ccachehelper cannot be compiled; ensure gokrb5 is available"; exit 1; }
 command -v make >/dev/null 2>&1 || { echo >&2 "make command not installed or in PATH"; exit 1; }
 command -v terraform >/dev/null 2>&1 || test -n "${TF_ACC_TERRAFORM_PATH:-}" || { echo >&2 "terraform command not installed or in PATH, TF_ACC_TERRAFORM_PATH not set"; exit 1; }
 grep -q "ns.example.com" /etc/hosts || echo >&2 "127.0.0.1 ns.example.com not found in /etc/hosts, ensure this mapping is handled in DNS resolution configuration"
@@ -126,6 +126,5 @@ docker run --privileged --cgroupns=host -d --tmpfs /tmp --tmpfs /run \
 	-p 127.0.0.1:15353:53 \
 	-p 127.0.0.1:15353:53/udp \
 	--rm --name ns --hostname ns.example.com ns || failed
-echo "password" | kinit --password-file=STDIN test@EXAMPLE.COM || echo "password" | kinit test@EXAMPLE.COM
-GO111MODULE=on make testacc TEST=./internal/provider || failed
+KRB5CCNAME=$(DNS_UPDATE_USERNAME="test" DNS_UPDATE_PASSWORD="password" go run ./internal/provider/ccachehelper/) GO111MODULE=on make testacc TEST=./internal/provider || failed
 cleanup_docker

--- a/internal/provider/ccachehelper/main.go
+++ b/internal/provider/ccachehelper/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/iana/nametype"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+type byteWriter struct {
+	buf []byte
+}
+
+func (w *byteWriter) writeInt8(v int8) {
+	w.buf = append(w.buf, byte(v))
+}
+
+func (w *byteWriter) writeInt16(v int16) {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(v))
+	w.buf = append(w.buf, b...)
+}
+
+func (w *byteWriter) writeInt32(v int32) {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(v))
+	w.buf = append(w.buf, b...)
+}
+
+func (w *byteWriter) writeData(data []byte) {
+	w.writeInt32(int32(len(data)))
+	w.buf = append(w.buf, data...)
+}
+
+func (w *byteWriter) writeTimestamp(t time.Time) {
+	w.writeInt32(int32(t.Unix()))
+}
+
+func (w *byteWriter) writePrincipal(nameType, numComponents int32, realm string, components []string) {
+	w.writeInt32(nameType)
+	w.writeInt32(numComponents)
+	w.writeData([]byte(realm))
+	for _, comp := range components {
+		w.writeData([]byte(comp))
+	}
+}
+
+func (w *byteWriter) writeCredential(clientName, clientRealm string, serverName, serverRealm string, key types.EncryptionKey, authTime, startTime, endTime, renewTill time.Time, flags asn1.BitString, ticket, secondTicket []byte) {
+	w.writePrincipal(nametype.KRB_NT_PRINCIPAL, 1, clientRealm, []string{clientName})
+	w.writePrincipal(nametype.KRB_NT_SRV_INST, 1, serverRealm, []string{serverName, serverRealm})
+	w.writeInt16(int16(key.KeyType))
+	w.writeData(key.KeyValue)
+	w.writeTimestamp(authTime)
+	w.writeTimestamp(startTime)
+	w.writeTimestamp(endTime)
+	w.writeTimestamp(renewTill)
+	w.writeInt8(0)
+	w.buf = append(w.buf, flags.Bytes...)
+	w.writeInt32(0)
+	w.writeInt32(0)
+	w.writeData(ticket)
+	w.writeData(secondTicket)
+}
+
+func getSessionData(cl *client.Client) (realm string, authTime, endTime, renewTill time.Time, tgt messages.Ticket, sessionKey types.EncryptionKey, err error) {
+	v := reflect.ValueOf(cl).Elem()
+
+	sessionsField := v.FieldByName("sessions")
+	if !sessionsField.IsValid() {
+		return "", time.Time{}, time.Time{}, time.Time{}, messages.Ticket{}, types.EncryptionKey{}, fmt.Errorf("could not find sessions field on client")
+	}
+
+	entriesField := sessionsField.Elem().FieldByName("Entries")
+	if !entriesField.IsValid() {
+		return "", time.Time{}, time.Time{}, time.Time{}, messages.Ticket{}, types.EncryptionKey{}, fmt.Errorf("could not find Entries field on sessions")
+	}
+
+	for _, key := range entriesField.MapKeys() {
+		sessionVal := entriesField.MapIndex(key).Elem()
+
+		r := sessionVal.FieldByName("realm").String()
+		at := sessionVal.FieldByName("authTime").Interface().(time.Time)
+		et := sessionVal.FieldByName("endTime").Interface().(time.Time)
+		rt := sessionVal.FieldByName("renewTill").Interface().(time.Time)
+		t := sessionVal.FieldByName("tgt").Interface().(messages.Ticket)
+		sk := sessionVal.FieldByName("sessionKey").Interface().(types.EncryptionKey)
+
+		return r, at, et, rt, t, sk, nil
+	}
+
+	return "", time.Time{}, time.Time{}, time.Time{}, messages.Ticket{}, types.EncryptionKey{}, fmt.Errorf("no session found")
+}
+
+func main() {
+	realm := os.Getenv("DNS_UPDATE_REALM")
+	if realm == "" {
+		realm = "EXAMPLE.COM"
+	}
+	username := os.Getenv("DNS_UPDATE_USERNAME")
+	if username == "" {
+		fmt.Fprintln(os.Stderr, "DNS_UPDATE_USERNAME is required")
+		os.Exit(1)
+	}
+	krb5ConfigPath := os.Getenv("KRB5_CONFIG")
+	if krb5ConfigPath == "" {
+		fmt.Fprintln(os.Stderr, "KRB5_CONFIG is required")
+		os.Exit(1)
+	}
+
+	cfg, err := config.Load(krb5ConfigPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load krb5 config: %v\n", err)
+		os.Exit(1)
+	}
+
+	password := os.Getenv("DNS_UPDATE_PASSWORD")
+	if password == "" {
+		fmt.Fprintln(os.Stderr, "DNS_UPDATE_PASSWORD is required")
+		os.Exit(1)
+	}
+
+	cl := client.NewWithPassword(username, realm, password, cfg,
+		client.DisablePAFXFAST(true),
+	)
+
+	if err := cl.Login(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to login to KDC: %v\n", err)
+		os.Exit(1)
+	}
+	defer cl.Destroy()
+
+	sRealm, authTime, endTime, renewTill, tgt, sessionKey, err := getSessionData(cl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get session data: %v\n", err)
+		os.Exit(1)
+	}
+
+	ticketBytes, err := tgt.Marshal()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal TGT: %v\n", err)
+		os.Exit(1)
+	}
+
+	var flagsBytes [4]byte
+	binary.BigEndian.PutUint32(flagsBytes[:], 0x400000)
+	flags := asn1.BitString{
+		Bytes:     flagsBytes[:],
+		BitLength: 32,
+	}
+
+	var w byteWriter
+	w.writeInt8(5)
+	w.writeInt8(4)
+
+	w.writePrincipal(
+		nametype.KRB_NT_PRINCIPAL, 1,
+		realm,
+		[]string{username},
+	)
+
+	w.writeCredential(
+		username, realm,
+		"krbtgt", sRealm,
+		sessionKey,
+		authTime, authTime, endTime, renewTill,
+		flags,
+		ticketBytes, nil,
+	)
+
+	cachePath := filepath.Join(os.TempDir(), "krb5cc_dnshelper")
+	if err := os.WriteFile(cachePath, w.buf, 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write credential cache: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(cachePath)
+}


### PR DESCRIPTION
Replace the `kinit` dependency in `acceptance.sh` with a Go helper that uses gokrb5 to authenticate with the KDC and write a credential cache file programmatically.

- Adds `internal/provider/ccachehelper/main.go` - a Go helper that uses `gokrb5/v8` to login to the KDC and write a credential cache file in binary format
- Removes the `kinit` executable check from `acceptance.sh`
- Replaces the `kinit` call for Kerberos session auth tests with the Go helper
- Promotes gokrb5 from indirect to direct dependency

Fixes #159