### PR TITLE
Make name optional in dns_ns_record_set for apex NS management (#129)

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260727-193600.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260727-193600.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Make name optional in dns_ns_record_set to allow managing apex NS records
+time: 2026-07-27T19:36:00.00000+02:00
+custom:
+    Issue: "129"

--- a/internal/provider/resource_dns_ns_record_set.go
+++ b/internal/provider/resource_dns_ns_record_set.go
@@ -38,11 +38,11 @@ type dnsNSRecordSetResource struct {
 	client *DNSClient
 }
 
-func (d *dnsNSRecordSetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (d *dnsNSRecordSetResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_ns_record_set"
 }
 
-func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (d *dnsNSRecordSetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Creates an NS type DNS record set.",
 		Attributes: map[string]schema.Attribute{
@@ -57,7 +57,7 @@ func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.Schema
 				Description: "DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.",
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -65,7 +65,7 @@ func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.Schema
 					dnsvalidator.IsRecordNameValid(),
 				},
 				Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+					"the full record path. If not set, the zone apex is used.",
 			},
 			"ttl": schema.Int64Attribute{
 				Optional: true,
@@ -92,19 +92,17 @@ func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.Schema
 	}
 }
 
-func (d *dnsNSRecordSetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (d *dnsNSRecordSetResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
 	client, ok := req.ProviderData.(*DNSClient)
-
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *DNSClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
-
 		return
 	}
 
@@ -136,17 +134,16 @@ func (d *dnsNSRecordSetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// Loop through all the new nameservers and insert them
 	for _, nameserver := range planNS {
 		rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
 
-		rr_insert, err := dns.NewRR(rrStr)
+		rrInsert, err := dns.NewRR(rrStr)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 			return
 		}
 
-		msg.Insert([]dns.RR{rr_insert})
+		msg.Insert([]dns.RR{rrInsert})
 	}
 
 	r, err := exchange(msg, true, d.client)
@@ -298,29 +295,27 @@ func (d *dnsNSRecordSetResource) Update(ctx context.Context, req resource.Update
 			remove = append(remove, oldNS)
 		}
 
-		// Loop through all the old nameservers and remove them
 		for _, nameserver := range remove {
 			rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
 
-			rr_remove, err := dns.NewRR(rrStr)
+			rrRemove, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
 
-			msg.Remove([]dns.RR{rr_remove})
+			msg.Remove([]dns.RR{rrRemove})
 		}
-		// Loop through all the new nameservers and insert them
 		for _, nameserver := range add {
 			rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
 
-			rr_insert, err := dns.NewRR(rrStr)
+			rrInsert, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
 
-			msg.Insert([]dns.RR{rr_insert})
+			msg.Insert([]dns.RR{rrInsert})
 		}
 
 		r, err := exchange(msg, true, d.client)
@@ -379,6 +374,30 @@ func (d *dnsNSRecordSetResource) Delete(ctx context.Context, req resource.Delete
 	config := dnsConfig{
 		Name: state.Name.ValueString(),
 		Zone: state.Zone.ValueString(),
+	}
+
+	// Check current NS record count to prevent removing the last NS record
+	answers, diags := resourceDnsRead_framework(config, d.client, dns.TypeNS)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	remaining := 0
+	for _, ans := range answers {
+		_, ok := ans.(*dns.NS)
+		if ok {
+			remaining++
+		}
+	}
+
+	if remaining <= 1 {
+		resp.Diagnostics.AddWarning("Cannot delete last NS record",
+			fmt.Sprintf("There is %d NS record remaining at %s. "+
+				"Removing the last NS record would make the zone unreachable. "+
+				"The resource will be removed from Terraform state.", remaining, resourceFQDN_framework(config)))
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	resp.Diagnostics.Append(resourceDnsDelete_framework(config, d.client, dns.TypeNS)...)

--- a/internal/provider/resource_dns_ns_record_set_test.go
+++ b/internal/provider/resource_dns_ns_record_set_test.go
@@ -124,6 +124,34 @@ func TestAccDnsNSRecordSet_Basic_Upgrade(t *testing.T) {
 	})
 }
 
+func TestAccDnsNSRecordSet_Apex(t *testing.T) {
+	resourceName := "dns_ns_record_set.apex"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsNSRecordSet_apex_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "nameservers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "ns1.apex.testdns.co.uk."),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "ns2.apex.testdns.co.uk."),
+				),
+			},
+			{
+				Config: testAccDnsNSRecordSet_apex_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "nameservers.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "ns1.apex.test2dns.co.uk."),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "ns2.apex.test2dns.co.uk."),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "ns3.apex.test2dns.co.uk."),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDnsNSRecordSetDestroy(s *terraform.State) error {
 	return testAccCheckDnsDestroy(s, "dns_ns_record_set", dns.TypeNS)
 }
@@ -144,5 +172,22 @@ var testAccDnsNSRecordSet_update = `
     zone = "example.com."
     name = "foo"
     nameservers = ["ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk.",]
+    ttl = 60
+  }`
+
+var testAccDnsNSRecordSet_apex_basic = `
+  resource "dns_ns_record_set" "apex" {
+    zone = "example.com."
+    nameservers = [
+      "ns1.apex.testdns.co.uk.",
+      "ns2.apex.testdns.co.uk.",
+    ]
+    ttl = 60
+  }`
+
+var testAccDnsNSRecordSet_apex_update = `
+  resource "dns_ns_record_set" "apex" {
+    zone = "example.com."
+    nameservers = ["ns1.apex.test2dns.co.uk.", "ns2.apex.test2dns.co.uk.", "ns3.apex.test2dns.co.uk."]
     ttl = 60
   }`


### PR DESCRIPTION
Changes the `name` attribute from Required to Optional in `dns_ns_record_set`. When not set, the zone apex is used.

Also adds a safety check in the Delete function to prevent removing the last NS record from a zone.

Closes #129