### PR TITLE
Clear existing PTR records before inserting on create to prevent Windows AD DNS conflicts

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-141.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-141.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Clear existing PTR records before inserting new ones in PTR record create to prevent conflicts with Windows AD DNS
+time: 2026-07-27T20:20:00.000000+02:00
+custom:
+    Issue: "141"

--- a/internal/provider/resource_dns_ptr_record.go
+++ b/internal/provider/resource_dns_ptr_record.go
@@ -125,6 +125,14 @@ func (d *dnsPTRRecordResource) Create(ctx context.Context, req resource.CreateRe
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
+	//nolint:errcheck
+	// Remove any existing PTR records at this name before inserting
+	rrStrRemove := fmt.Sprintf("%s 0 PTR", rec_fqdn)
+	rr_remove, err := dns.NewRR(rrStrRemove)
+	if err == nil {
+		msg.RemoveRRset([]dns.RR{rr_remove})
+	}
+
 	//Insert new PTR record
 	rrStrInsert := fmt.Sprintf("%s %d PTR %s", rec_fqdn, plan.TTL.ValueInt64(), plan.PTR.ValueString())
 

--- a/internal/provider/resource_dns_ptr_record_test.go
+++ b/internal/provider/resource_dns_ptr_record_test.go
@@ -120,6 +120,10 @@ func TestAccDnsPtrRecord_Basic_Upgrade(t *testing.T) {
 	})
 }
 
+func TestAccDnsPTRRecord_WindowsAD(t *testing.T) {
+	t.Skip("Requires Windows AD DNS server with GSSAPI configured")
+}
+
 func testAccCheckDnsPtrRecordDestroy(s *terraform.State) error {
 	return testAccCheckDnsDestroy(s, "dns_ptr_record", dns.TypePTR)
 }


### PR DESCRIPTION
The PTR record Create method was inserting a new PTR record without first clearing any existing PTR records at the same name. This could cause conflicts with Windows AD DNS, which may reject the update if a PTR record already exists.

This fix adds a `RemoveRRset` call before `Insert` during Create, aligning with the pattern used by A and AAAA record resources.

Additionally, the underlying GSSAPI threading issue (fixed in #664) could also cause the `unexpected acceptor flag is not set` error on Windows AD when multiple resources are processed in parallel.

Fixes #141