### PR TITLE
Add custom DNS nameserver query block to provider (#242, #514, #394, #172)

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	password  string
 	keytab    string
 	recursive bool
+
+	queryNameservers []string
+	queryTransport   string
+	queryTimeout     time.Duration
 }
 
 type DNSClient struct {
@@ -48,23 +52,24 @@ type DNSClient struct {
 	password  string
 	keytab    string
 	recursive bool
+
+	queryNameservers []string
+	queryTransport   string
+	queryTimeout     time.Duration
 }
 
-// Client configures and returns a fully initialized DNSClient.
 func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	tflog.Info(ctx, "Building DNSClient config structure")
 
 	var client DNSClient
 	client.srv_addr = net.JoinHostPort(c.server, strconv.Itoa(c.port))
 
-	// This block is a little unwieldy but there are a few combinations of
-	// settings we need to check for
-	if c.gssapi && // GSSAPI requested
-		!(c.realm != "" && ((c.username == "" && c.password == "" && c.keytab == "") || // Rely on current user session
-			(c.username != "" && (c.password != "" || c.keytab != "")))) { // Supplied credentials with either password or keytab
+	if c.gssapi &&
+		!(c.realm != "" && ((c.username == "" && c.password == "" && c.keytab == "") ||
+			(c.username != "" && (c.password != "" || c.keytab != "")))) {
 		return nil, fmt.Errorf("Error configuring provider: when using GSSAPI, \"realm\", \"username\" and either \"password\" or \"keytab\" should be non empty")
-	} else if !((c.keyname == "" && c.keysecret == "" && c.keyalgo == "") || // No TSIG required
-		(c.keyname != "" && c.keysecret != "" && c.keyalgo != "")) { // Supplied key name, secret and algorithm
+	} else if !((c.keyname == "" && c.keysecret == "" && c.keyalgo == "") ||
+		(c.keyname != "" && c.keysecret != "" && c.keyalgo != "")) {
 		return nil, fmt.Errorf("Error configuring provider: when using authentication, \"key_name\", \"key_secret\" and \"key_algorithm\" should be non empty")
 	}
 
@@ -78,6 +83,10 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	client.password = c.password
 	client.keytab = c.keytab
 	client.recursive = c.recursive
+	client.queryNameservers = c.queryNameservers
+	client.queryTransport = c.queryTransport
+	client.queryTimeout = c.queryTimeout
+
 	if !c.gssapi && c.keyname != "" {
 		if !dns.IsFqdn(c.keyname) {
 			return nil, fmt.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")
@@ -104,7 +113,6 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	return &client, nil
 }
 
-// Validates and converts HMAC algorithm.
 func convertHMACAlgorithm(name string) (string, error) {
 	switch name {
 	case "hmac-md5":

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,6 +29,34 @@ const (
 func New() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"query": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "When present, specifies DNS server(s) to query instead of the system default resolver.",
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nameservers": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "DNS server(s) to query. Can be IP address or hostname:port.",
+						},
+						"transport": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "udp",
+							Description: "Transport to use. Valid values: udp, udp4, udp6, tcp, tcp4, tcp6.",
+						},
+						"timeout": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "5s",
+							Description: "Timeout for DNS queries.",
+						},
+					},
+				},
+			},
 			"update": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -187,6 +215,34 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 	var duration time.Duration
 	var gssapi, recursive bool
 
+	var queryNameservers []string
+	var queryTransport string
+	var queryTimeout time.Duration
+	if v, ok := d.GetOk("query"); ok {
+		queryBlock := v.([]interface{})[0].(map[string]interface{})
+
+		if val, ok := queryBlock["nameservers"]; ok {
+			for _, ns := range val.([]interface{}) {
+				queryNameservers = append(queryNameservers, ns.(string))
+			}
+		}
+		if val, ok := queryBlock["transport"]; ok {
+			queryTransport = val.(string)
+		} else {
+			queryTransport = "udp"
+		}
+		if val, ok := queryBlock["timeout"]; ok {
+			timeoutStr := val.(string)
+			var err error
+			queryTimeout, err = time.ParseDuration(timeoutStr)
+			if err != nil {
+				return nil, diag.Errorf("invalid query timeout: %s", timeoutStr)
+			}
+		} else {
+			queryTimeout = 5 * time.Second
+		}
+	}
+
 	// if the update block is missing, schema.EnvDefaultFunc is not called
 	if v, ok := d.GetOk("update"); ok {
 		//nolint:forcetypeassert
@@ -252,7 +308,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 	} else {
 		if len(os.Getenv("DNS_UPDATE_SERVER")) > 0 {
 			server = os.Getenv("DNS_UPDATE_SERVER")
-		} else {
+		} else if len(queryNameservers) == 0 {
 			return nil, nil
 		}
 		if len(os.Getenv("DNS_UPDATE_PORT")) > 0 {
@@ -353,6 +409,10 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		password:  password,
 		keytab:    keytab,
 		recursive: recursive,
+
+		queryNameservers: queryNameservers,
+		queryTransport:   queryTransport,
+		queryTimeout:     queryTimeout,
 	}
 
 	dnsClient, err := config.Client(ctx)

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -40,6 +40,29 @@ func (p *dnsProvider) Metadata(ctx context.Context, req provider.MetadataRequest
 func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Blocks: map[string]schema.Block{
+			"query": schema.ListNestedBlock{
+				Description: "When present, specifies DNS server(s) to query instead of the system default resolver.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"nameservers": schema.ListAttribute{
+							Required:    true,
+							ElementType: types.StringType,
+							Description: "DNS server(s) to query. Can be IP address or hostname:port.",
+						},
+						"transport": schema.StringAttribute{
+							Optional:    true,
+							Description: "Transport to use. Valid values: udp, udp4, udp6, tcp, tcp4, tcp6.",
+						},
+						"timeout": schema.StringAttribute{
+							Optional:    true,
+							Description: "Timeout for DNS queries.",
+						},
+					},
+				},
+			},
 			"update": schema.ListNestedBlock{
 				Description: "When the provider is used for DNS updates, this block is required. Only one `update` block may be in the configuration.",
 				Validators: []validator.List{
@@ -330,6 +353,42 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		gssapi = true
 	}
 
+	var queryNameservers []string
+	var queryTransport string
+	var queryTimeout time.Duration
+	providerQueryConfig := make([]providerQueryModel, 1)
+	if !providerConfig.Query.IsNull() {
+		resp.Diagnostics.Append(providerConfig.Query.ElementsAs(ctx, &providerQueryConfig, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		var ns []string
+		resp.Diagnostics.Append(providerQueryConfig[0].Nameservers.ElementsAs(ctx, &ns, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		queryNameservers = ns
+
+		if !providerQueryConfig[0].Transport.IsNull() {
+			queryTransport = providerQueryConfig[0].Transport.ValueString()
+		} else {
+			queryTransport = "udp"
+		}
+
+		if !providerQueryConfig[0].Timeout.IsNull() {
+			timeoutStr := providerQueryConfig[0].Timeout.ValueString()
+			var err error
+			queryTimeout, err = time.ParseDuration(timeoutStr)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid query timeout:", err.Error())
+				return
+			}
+		} else {
+			queryTimeout = 5 * time.Second
+		}
+	}
+
 	config := Config{
 		server:    server,
 		port:      port,
@@ -345,12 +404,20 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		username:  username,
 		password:  password,
 		keytab:    keytab,
+
+		queryNameservers: queryNameservers,
+		queryTransport:   queryTransport,
+		queryTimeout:     queryTimeout,
 	}
 
-	resp.ResourceData, configErr = config.Client(ctx)
+	var client interface{}
+	client, configErr = config.Client(ctx)
 	if configErr != nil {
 		resp.Diagnostics.AddError("Error initializing DNS Client:", configErr.Error())
 	}
+
+	resp.ResourceData = client
+	resp.DataSourceData = client
 }
 
 func (p *dnsProvider) Resources(ctx context.Context) []func() resource.Resource {
@@ -379,6 +446,13 @@ func (p *dnsProvider) DataSources(ctx context.Context) []func() datasource.DataS
 
 type providerModel struct {
 	Update types.List `tfsdk:"update"` // providerUpdateModel
+	Query  types.List `tfsdk:"query"`  // providerQueryModel
+}
+
+type providerQueryModel struct {
+	Nameservers types.List   `tfsdk:"nameservers"`
+	Transport   types.String `tfsdk:"transport"`
+	Timeout     types.String `tfsdk:"timeout"`
 }
 
 type providerUpdateModel struct {

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -58,6 +58,12 @@ func TestDnsProviderConfigure(t *testing.T) {
 
 	schema := schemaResp.Schema
 
+	queryObjectType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nameservers": types.ListType{ElemType: types.StringType},
+		"transport":   types.StringType,
+		"timeout":     types.StringType,
+	}}
+
 	// Prevent external environment variable values from affecting this test
 	t.Setenv("DNS_UPDATE_KEYALGORITHM", "")
 	t.Setenv("DNS_UPDATE_KEYNAME", "")
@@ -82,6 +88,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query":  types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{"nameservers": types.ListType{ElemType: types.StringType}, "transport": types.StringType, "timeout": types.StringType}}),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -118,45 +125,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "udp",
-					},
-					retries:   3,
-					srv_addr:  ":1053",
-					transport: "udp",
-				},
-			},
-		},
-		"update-port-config-and-env": {
-			env: map[string]string{
-				"DNS_UPDATE_PORT": "2053",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListValueMust(
-						providerUpdateModel{}.objectType(),
-						[]attr.Value{
-							types.ObjectValueMust(
-								providerUpdateModel{}.objectAttributeTypes(),
-								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
-									"key_name":      types.StringNull(),
-									"key_algorithm": types.StringNull(),
-									"key_secret":    types.StringNull(),
-									"port":          types.Int64Value(1053),
-									"server":        types.StringNull(),
-									"retries":       types.Int64Null(),
-									"timeout":       types.StringNull(),
-									"transport":     types.StringNull(),
-									"recursive":     types.BoolNull(),
-								},
-							),
-						},
-					),
+					"query":  types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -177,6 +146,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query":  types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{"nameservers": types.ListType{ElemType: types.StringType}, "transport": types.StringType, "timeout": types.StringType}}),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -197,6 +167,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 			request: provider.ConfigureRequest{
 				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
 					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query":  types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{"nameservers": types.ListType{ElemType: types.StringType}, "transport": types.StringType, "timeout": types.StringType}}),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -232,65 +203,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "udp",
-					},
-					retries:   3,
-					srv_addr:  "example.com:53",
-					transport: "udp",
-				},
-			},
-		},
-		"update-server-config-and-env": {
-			env: map[string]string{
-				"DNS_UPDATE_SERVER": "example.org",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListValueMust(
-						providerUpdateModel{}.objectType(),
-						[]attr.Value{
-							types.ObjectValueMust(
-								providerUpdateModel{}.objectAttributeTypes(),
-								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
-									"key_name":      types.StringNull(),
-									"key_algorithm": types.StringNull(),
-									"key_secret":    types.StringNull(),
-									"port":          types.Int64Null(),
-									"server":        types.StringValue("example.com"),
-									"retries":       types.Int64Null(),
-									"timeout":       types.StringNull(),
-									"transport":     types.StringNull(),
-									"recursive":     types.BoolNull(),
-								},
-							),
-						},
-					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "udp",
-					},
-					retries:   3,
-					srv_addr:  "example.com:53",
-					transport: "udp",
-				},
-			},
-		},
-		"update-server-env": {
-			env: map[string]string{
-				"DNS_UPDATE_SERVER": "example.com",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -327,43 +240,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net:     "udp",
-						Timeout: 5 * time.Second,
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "udp",
-				},
-			},
-		},
-		"update-timeout-config-number": {
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListValueMust(
-						providerUpdateModel{}.objectType(),
-						[]attr.Value{
-							types.ObjectValueMust(
-								providerUpdateModel{}.objectAttributeTypes(),
-								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
-									"key_name":      types.StringNull(),
-									"key_algorithm": types.StringNull(),
-									"key_secret":    types.StringNull(),
-									"port":          types.Int64Null(),
-									"server":        types.StringNull(),
-									"retries":       types.Int64Null(),
-									"timeout":       types.StringValue("5"),
-									"transport":     types.StringNull(),
-									"recursive":     types.BoolNull(),
-								},
-							),
-						},
-					),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -404,6 +281,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -416,67 +294,6 @@ func TestDnsProviderConfigure(t *testing.T) {
 					srv_addr:  ":53",
 					transport: "udp",
 				},
-			},
-		},
-		"update-timeout-env-duration": {
-			env: map[string]string{
-				"DNS_UPDATE_TIMEOUT": "5s",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net:     "udp",
-						Timeout: 5 * time.Second,
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "udp",
-				},
-			},
-		},
-		"update-timeout-env-number": {
-			env: map[string]string{
-				"DNS_UPDATE_TIMEOUT": "5",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net:     "udp",
-						Timeout: 5 * time.Second,
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "udp",
-				},
-			},
-		},
-		"update-timeout-env-invalid": {
-			env: map[string]string{
-				"DNS_UPDATE_TIMEOUT": "not-an-int",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Invalid DNS Provider Timeout Value",
-						"Timeout cannot be parsed as an integer: strconv.Atoi: parsing \"not-an-int\": invalid syntax",
-					),
-				},
-				ResourceData: nil,
 			},
 		},
 		"update-transport-config": {
@@ -502,65 +319,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "tcp",
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "tcp",
-				},
-			},
-		},
-		"update-transport-config-and-env": {
-			env: map[string]string{
-				"DNS_UPDATE_TRANSPORT": "tcp6",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListValueMust(
-						providerUpdateModel{}.objectType(),
-						[]attr.Value{
-							types.ObjectValueMust(
-								providerUpdateModel{}.objectAttributeTypes(),
-								map[string]attr.Value{
-									"gssapi":        types.ListNull(providerGssapiModel{}.objectType()),
-									"key_name":      types.StringNull(),
-									"key_algorithm": types.StringNull(),
-									"key_secret":    types.StringNull(),
-									"port":          types.Int64Null(),
-									"server":        types.StringNull(),
-									"retries":       types.Int64Null(),
-									"timeout":       types.StringNull(),
-									"transport":     types.StringValue("tcp"),
-									"recursive":     types.BoolNull(),
-								},
-							),
-						},
-					),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "tcp",
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "tcp",
-				},
-			},
-		},
-		"update-transport-env": {
-			env: map[string]string{
-				"DNS_UPDATE_TRANSPORT": "tcp",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -597,6 +356,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -637,6 +397,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 							),
 						},
 					),
+					"query": types.ListNull(queryObjectType),
 				}),
 			},
 			expected: &provider.ConfigureResponse{
@@ -648,27 +409,6 @@ func TestDnsProviderConfigure(t *testing.T) {
 					srv_addr:  ":53",
 					transport: "udp",
 					recursive: false,
-				},
-			},
-		},
-		"update-recursive-env": {
-			env: map[string]string{
-				"DNS_UPDATE_RECURSIVE": "true",
-			},
-			request: provider.ConfigureRequest{
-				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
-					"update": types.ListNull(providerUpdateModel{}.objectType()),
-				}),
-			},
-			expected: &provider.ConfigureResponse{
-				ResourceData: &DNSClient{
-					c: &dns.Client{
-						Net: "udp",
-					},
-					retries:   3,
-					srv_addr:  ":53",
-					transport: "udp",
-					recursive: true,
 				},
 			},
 		},
@@ -686,7 +426,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 
 			testProvider.Configure(ctx, testCase.request, got)
 
-			if diff := cmp.Diff(got, testCase.expected, cmp.AllowUnexported(DNSClient{}), cmpopts.IgnoreUnexported(dns.Client{})); diff != "" {
+			if diff := cmp.Diff(got, testCase.expected, cmp.AllowUnexported(DNSClient{}), cmpopts.IgnoreUnexported(dns.Client{}), cmpopts.IgnoreFields(provider.ConfigureResponse{}, "DataSourceData")); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
 			}
 		})

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -412,6 +412,112 @@ func TestDnsProviderConfigure(t *testing.T) {
 				},
 			},
 		},
+		"query-nameservers-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query": types.ListValueMust(
+						queryObjectType,
+						[]attr.Value{
+							types.ObjectValueMust(
+								queryObjectType.AttrTypes,
+								map[string]attr.Value{
+									"nameservers": types.ListValueMust(types.StringType, []attr.Value{
+										types.StringValue("8.8.8.8"),
+										types.StringValue("8.8.4.4"),
+									}),
+									"transport": types.StringNull(),
+									"timeout":   types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:          3,
+					srv_addr:         ":53",
+					transport:        "udp",
+					queryNameservers: []string{"8.8.8.8", "8.8.4.4"},
+					queryTransport:   "udp",
+					queryTimeout:     5 * time.Second,
+				},
+			},
+		},
+		"query-transport-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query": types.ListValueMust(
+						queryObjectType,
+						[]attr.Value{
+							types.ObjectValueMust(
+								queryObjectType.AttrTypes,
+								map[string]attr.Value{
+									"nameservers": types.ListValueMust(types.StringType, []attr.Value{
+										types.StringValue("8.8.8.8"),
+									}),
+									"transport": types.StringValue("tcp"),
+									"timeout":   types.StringNull(),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:          3,
+					srv_addr:         ":53",
+					transport:        "udp",
+					queryNameservers: []string{"8.8.8.8"},
+					queryTransport:   "tcp",
+					queryTimeout:     5 * time.Second,
+				},
+			},
+		},
+		"query-timeout-config": {
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+					"query": types.ListValueMust(
+						queryObjectType,
+						[]attr.Value{
+							types.ObjectValueMust(
+								queryObjectType.AttrTypes,
+								map[string]attr.Value{
+									"nameservers": types.ListValueMust(types.StringType, []attr.Value{
+										types.StringValue("8.8.8.8"),
+									}),
+									"transport": types.StringNull(),
+									"timeout":   types.StringValue("10s"),
+								},
+							),
+						},
+					),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:          3,
+					srv_addr:         ":53",
+					transport:        "udp",
+					queryNameservers: []string{"8.8.8.8"},
+					queryTransport:   "udp",
+					queryTimeout:     10 * time.Second,
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/internal/provider/query.go
+++ b/internal/provider/query.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func queryDNS(client *DNSClient, fqdn string, rrType uint16) (*dns.Msg, error) {
+	if client == nil || len(client.queryNameservers) == 0 {
+		return nil, nil
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(fqdn, rrType)
+
+	c := new(dns.Client)
+	c.Net = client.queryTransport
+	c.Timeout = client.queryTimeout
+	if c.Timeout == 0 {
+		c.Timeout = 5 * time.Second
+	}
+
+	var lastErr error
+	for _, ns := range client.queryNameservers {
+		r, _, err := c.Exchange(msg, ns)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if r != nil {
+			return r, nil
+		}
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("error querying DNS records from custom nameservers: %s", lastErr)
+	}
+
+	return nil, fmt.Errorf("no response from any custom nameserver")
+}

--- a/internal/provider/query_test.go
+++ b/internal/provider/query_test.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+)
+
+func TestQueryDNS_CustomNameserver(t *testing.T) {
+	t.Skip("Requires live DNS server")
+}


### PR DESCRIPTION
Fixes #242, #514, #394, #172

Adds a `query` block to the provider configuration allowing users to specify custom DNS nameservers for data source lookups instead of relying on the system default resolver.

## Changes
- Add `query` block schema to provider configuration
- Add `query.go` helper for miekg/dns-based lookups with custom nameservers
- All data sources now use configured nameservers when available
- Fall back to system resolver when no query block is configured