### PR TITLE
docs: add note about record scavenging to documentation and resource descriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ description: |-
 
 The DNS provider supports resources that perform DNS updates ([RFC 2136](https://datatracker.ietf.org/doc/html/rfc2136)) and data sources for reading DNS information. The provider can be configured with secret key based transaction authentication ([RFC 2845](https://datatracker.ietf.org/doc/html/rfc2845)) or GSS-TSIG ([RFC 3645](https://datatracker.ietf.org/doc/html/rfc3645)).
 
+~> **Note on record scavenging:** DNS records created by this provider use DNS dynamic updates, which some DNS servers (notably Microsoft Windows DNS) may mark as scavengable by default. This means records can be automatically removed when scavenging is enabled. To create static (non-scavengable) records on Windows DNS, use PowerShell's `Add-DnsServerResourceRecord -AgeRecord $false` or configure scavenging settings appropriately. On BIND, configure `allow-update` with appropriate zone settings. This behavior is controlled by the DNS server, not by this provider.
+
 Use the navigation to the left to read about the available resources and data sources.
 
 ## Example Usage

--- a/internal/provider/resource_dns_a_record_set.go
+++ b/internal/provider/resource_dns_a_record_set.go
@@ -56,7 +56,7 @@ func resourceDnsARecordSet() *schema.Resource {
 			},
 		},
 
-		Description: "Creates an A type DNS record set.",
+		Description: "Creates an A type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 	}
 }
 

--- a/internal/provider/resource_dns_aaaa_record_set.go
+++ b/internal/provider/resource_dns_aaaa_record_set.go
@@ -56,7 +56,7 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 			},
 		},
 
-		Description: "Creates an AAAA type DNS record set.",
+		Description: "Creates an AAAA type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 	}
 }
 

--- a/internal/provider/resource_dns_cname_record.go
+++ b/internal/provider/resource_dns_cname_record.go
@@ -40,7 +40,7 @@ func (d *dnsCNAMERecordResource) Metadata(ctx context.Context, req resource.Meta
 
 func (d *dnsCNAMERecordResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates a CNAME type DNS record.",
+		Description: "Creates a CNAME type DNS record. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_mx_record_set.go
+++ b/internal/provider/resource_dns_mx_record_set.go
@@ -43,7 +43,7 @@ func (d *dnsMXRecordSetResource) Metadata(ctx context.Context, req resource.Meta
 
 func (d *dnsMXRecordSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates an MX type DNS record set.",
+		Description: "Creates an MX type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_ns_record_set.go
+++ b/internal/provider/resource_dns_ns_record_set.go
@@ -44,7 +44,7 @@ func (d *dnsNSRecordSetResource) Metadata(ctx context.Context, req resource.Meta
 
 func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates an NS type DNS record set.",
+		Description: "Creates an NS type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_ptr_record.go
+++ b/internal/provider/resource_dns_ptr_record.go
@@ -40,7 +40,7 @@ func (d *dnsPTRRecordResource) Metadata(ctx context.Context, req resource.Metada
 
 func (d *dnsPTRRecordResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates a PTR type DNS record.",
+		Description: "Creates a PTR type DNS record. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_srv_record_set.go
+++ b/internal/provider/resource_dns_srv_record_set.go
@@ -43,7 +43,7 @@ func (d *dnsSRVRecordSetResource) Metadata(ctx context.Context, req resource.Met
 
 func (d *dnsSRVRecordSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates an SRV type DNS record set.",
+		Description: "Creates an SRV type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_txt_record_set.go
+++ b/internal/provider/resource_dns_txt_record_set.go
@@ -44,7 +44,7 @@ func (d *dnsTXTRecordSetResource) Metadata(ctx context.Context, req resource.Met
 
 func (d *dnsTXTRecordSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates a TXT type DNS record set.",
+		Description: "Creates a TXT type DNS record set. Note: DNS servers may mark records created via dynamic update as scavengable; see provider documentation for details.",
 		Attributes: map[string]schema.Attribute{
 			"zone": schema.StringAttribute{
 				Required: true,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -8,6 +8,8 @@ description: |-
 
 The DNS provider supports resources that perform DNS updates ([RFC 2136](https://datatracker.ietf.org/doc/html/rfc2136)) and data sources for reading DNS information. The provider can be configured with secret key based transaction authentication ([RFC 2845](https://datatracker.ietf.org/doc/html/rfc2845)) or GSS-TSIG ([RFC 3645](https://datatracker.ietf.org/doc/html/rfc3645)).
 
+~> **Note on record scavenging:** DNS records created by this provider use DNS dynamic updates, which some DNS servers (notably Microsoft Windows DNS) may mark as scavengable by default. This means records can be automatically removed when scavenging is enabled. To create static (non-scavengable) records on Windows DNS, use PowerShell's `Add-DnsServerResourceRecord -AgeRecord $false` or configure scavenging settings appropriately. On BIND, configure `allow-update` with appropriate zone settings. This behavior is controlled by the DNS server, not by this provider.
+
 Use the navigation to the left to read about the available resources and data sources.
 
 ## Example Usage


### PR DESCRIPTION
## Description

DNS records created via dynamic update (RFC 2136) may be marked as scavengable by some DNS servers. This is a server-side behavior that the provider cannot control through the DNS update protocol. This PR adds documentation to clarify this and provide guidance for creating static records.

### Changes:
- Added note to provider-level documentation in `templates/index.md.tmpl` and `docs/index.md`
- Updated `Description` field in all resource Go files to mention scavenging

Closes #581