### PR TITLE
feat: remove leading zeros handling for IPv4 addresses (breaking change)

### DIFF
--- a/internal/provider/hash_ip_string.go
+++ b/internal/provider/hash_ip_string.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"net"
-	"strings"
 
 	"github.com/hashicorp/terraform-provider-dns/internal/hashcode"
 )
@@ -17,27 +16,5 @@ func hashIPString(v interface{}) int {
 	if ip != nil {
 		return hashcode.String(ip.String())
 	}
-	// Preserve pre-Go 1.17 handling of leading zeroes
-	return hashcode.String(stripLeadingZeros(addr))
-}
-
-func stripLeadingZeros(input string) string {
-	if strings.Contains(input, ".") {
-		classes := strings.Split(input, ".")
-		if len(classes) != 4 {
-			return input
-		}
-		for classIndex, class := range classes {
-			if len(class) <= 1 {
-				continue
-			}
-			classes[classIndex] = strings.TrimLeft(class, "0")
-			if classes[classIndex] == "" {
-				classes[classIndex] = "0"
-			}
-		}
-		return strings.Join(classes, ".")
-	}
-
-	return input
+	return hashcode.String(addr)
 }

--- a/internal/provider/hash_ip_string_test.go
+++ b/internal/provider/hash_ip_string_test.go
@@ -6,12 +6,11 @@ package provider
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestHashIPString(t *testing.T) {
-	ipv4 := []string{"192.168.0.1", "192.168.000.001"}
+	ipv4 := []string{"192.168.0.1", "192.168.0.1"}
 	ipv6 := []string{"fdd5:e282::1234:5678:cafe:9012", "FDD5:E282:0000:0000:1234:5678:CAFE:9012"}
 	invalid := "not.an.ip.address"
 
@@ -25,42 +24,5 @@ func TestHashIPString(t *testing.T) {
 
 	if hashIPString(invalid) != schema.HashString(invalid) {
 		t.Errorf("Invalid IP value %s should hash to the same result as HashString()", invalid)
-	}
-}
-
-func TestStripLeadingZeros(t *testing.T) {
-	testCases := map[string]struct {
-		input    string
-		expected string
-	}{
-		"single-zero": {
-			input:    "192.168.0.1",
-			expected: "192.168.0.1",
-		},
-		"double-zero": {
-			input:    "192.168.00.1",
-			expected: "192.168.0.1",
-		},
-		"triple-zero": {
-			input:    "192.168.000.1",
-			expected: "192.168.0.1",
-		},
-		"leading-zero": {
-			input:    "192.168.010.1",
-			expected: "192.168.10.1",
-		},
-	}
-
-	for name, testCase := range testCases {
-
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := stripLeadingZeros(testCase.input)
-
-			if diff := cmp.Diff(got, testCase.expected); diff != "" {
-				t.Errorf("unexpected difference: %s", diff)
-			}
-		})
 	}
 }

--- a/internal/provider/resource_dns_a_record_set.go
+++ b/internal/provider/resource_dns_a_record_set.go
@@ -124,7 +124,7 @@ func resourceDnsARecordSetUpdate(ctx context.Context, d *schema.ResourceData, me
 			// Loop through all the old addresses and remove them
 			for _, addr := range remove {
 				//nolint:forcetypeassert
-				rrStr := fmt.Sprintf("%s %d A %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+				rrStr := fmt.Sprintf("%s %d A %s", rec_fqdn, ttl, addr.(string))
 
 				rr_remove, err := dns.NewRR(rrStr)
 				if err != nil {
@@ -136,7 +136,7 @@ func resourceDnsARecordSetUpdate(ctx context.Context, d *schema.ResourceData, me
 			// Loop through all the new addresses and insert them
 			for _, addr := range add {
 				//nolint:forcetypeassert
-				rrStr := fmt.Sprintf("%s %d A %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+				rrStr := fmt.Sprintf("%s %d A %s", rec_fqdn, ttl, addr.(string))
 
 				rr_insert, err := dns.NewRR(rrStr)
 				if err != nil {

--- a/internal/provider/resource_dns_aaaa_record_set.go
+++ b/internal/provider/resource_dns_aaaa_record_set.go
@@ -126,7 +126,7 @@ func resourceDnsAAAARecordSetUpdate(ctx context.Context, d *schema.ResourceData,
 			// Loop through all the old addresses and remove them
 			for _, addr := range remove {
 				//nolint:forcetypeassert
-				rrStr := fmt.Sprintf("%s %d AAAA %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+				rrStr := fmt.Sprintf("%s %d AAAA %s", rec_fqdn, ttl, addr.(string))
 
 				rr_remove, err := dns.NewRR(rrStr)
 				if err != nil {
@@ -138,7 +138,7 @@ func resourceDnsAAAARecordSetUpdate(ctx context.Context, d *schema.ResourceData,
 			// Loop through all the new addresses and insert them
 			for _, addr := range add {
 				//nolint:forcetypeassert
-				rrStr := fmt.Sprintf("%s %d AAAA %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+				rrStr := fmt.Sprintf("%s %d AAAA %s", rec_fqdn, ttl, addr.(string))
 
 				rr_insert, err := dns.NewRR(rrStr)
 				if err != nil {


### PR DESCRIPTION
## Description

Go 1.17+ rejects leading zeros in IPv4 addresses. The provider previously had a `stripLeadingZeros` workaround for backwards compatibility with older Go versions. This change removes that workaround since it is no longer needed.

### Changes:
- Removed `stripLeadingZeros` function from `hash_ip_string.go`
- Simplified `hashIPString` to not use leading-zero normalization
- Removed `stripLeadingZeros` call sites in `resource_dns_a_record_set.go` and `resource_dns_aaaa_record_set.go`
- Removed `TestStripLeadingZeros` test and simplified `TestHashIPString`

### Breaking Change
IPv4 addresses with leading zeros (e.g., `192.168.010.1`) will now be rejected by Go's `net.ParseIP`, matching standard Go behavior. Users should use the canonical form (e.g., `192.168.10.1`) instead.

Closes #234