### PR TITLE
feat: add AXFR zone transfer support for reading DNS records

### DIFF
--- a/internal/provider/axfr.go
+++ b/internal/provider/axfr.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/miekg/dns"
+)
+
+// axfrQuery performs a zone transfer (AXFR) and returns all records
+func axfrQuery(client *DNSClient, zone string) ([]dns.RR, error) {
+	m := new(dns.Msg)
+	m.SetAxfr(zone)
+
+	t := new(dns.Transfer)
+	t.TsigProvider = client.c.TsigProvider
+	t.DialTimeout = client.c.Timeout
+
+	ch, err := t.In(m, client.srv_addr)
+	if err != nil {
+		return nil, fmt.Errorf("error performing AXFR for zone %s: %s", zone, err)
+	}
+
+	var allRecords []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return nil, fmt.Errorf("error during AXFR for zone %s: %s", zone, env.Error)
+		}
+		allRecords = append(allRecords, env.RR...)
+	}
+	return allRecords, nil
+}

--- a/internal/provider/axfr_test.go
+++ b/internal/provider/axfr_test.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+)
+
+func TestAxfrQuery_NotAuthoritative(t *testing.T) {
+	t.Skip("AXFR requires zone transfer permissions; cannot unit test without infrastructure")
+}

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	password  string
 	keytab    string
 	recursive bool
+	useAxfr   bool
 }
 
 type DNSClient struct {
@@ -48,6 +49,7 @@ type DNSClient struct {
 	password  string
 	keytab    string
 	recursive bool
+	useAxfr   bool
 }
 
 // Client configures and returns a fully initialized DNSClient.
@@ -78,6 +80,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 	client.password = c.password
 	client.keytab = c.keytab
 	client.recursive = c.recursive
+	client.useAxfr = c.useAxfr
 	if !c.gssapi && c.keyname != "" {
 		if !dns.IsFqdn(c.keyname) {
 			return nil, fmt.Errorf("Error configuring provider: \"key_name\" should be fully-qualified")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -99,6 +99,13 @@ func New() *schema.Provider {
 							Default:     false,
 							Description: "Enable the Recursion Desired (RD) flag on DNS queries",
 						},
+						"use_axfr": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Use AXFR (zone transfer) to read DNS records instead of individual queries. " +
+								"Useful for large zones where querying each record individually is slow.",
+						},
 						"key_name": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -185,7 +192,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 	var server, transport, timeout, keyname, keyalgo, keysecret, realm, username, password, keytab string
 	var port, retries int
 	var duration time.Duration
-	var gssapi, recursive bool
+	var gssapi, recursive, useAxfr bool
 
 	// if the update block is missing, schema.EnvDefaultFunc is not called
 	if v, ok := d.GetOk("update"); ok {
@@ -214,6 +221,10 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		if val, ok := update["recursive"]; ok {
 			//nolint:forcetypeassert
 			recursive = val.(bool)
+		}
+		if val, ok := update["use_axfr"]; ok {
+			//nolint:forcetypeassert
+			useAxfr = val.(bool)
 		}
 		if val, ok := update["key_name"]; ok {
 			//nolint:forcetypeassert
@@ -353,6 +364,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		password:  password,
 		keytab:    keytab,
 		recursive: recursive,
+		useAxfr:   useAxfr,
 	}
 
 	dnsClient, err := config.Client(ctx)
@@ -652,13 +664,29 @@ func resourceDnsRead(d *schema.ResourceData, meta interface{}, rrType uint16) ([
 
 		fqdn := resourceFQDN(d)
 
-		msg := new(dns.Msg)
-		msg.SetQuestion(fqdn, rrType)
-
 		dnsClient, ok := meta.(*DNSClient)
 		if !ok {
 			return nil, diag.Errorf("Error asserting meta to *DNSClient")
 		}
+
+		if dnsClient.useAxfr {
+			zone := d.Get("zone").(string)
+			records, err := axfrQuery(dnsClient, zone)
+			if err != nil {
+				return nil, diag.Errorf("Error reading DNS records via AXFR: %s", err)
+			}
+
+			var matching []dns.RR
+			for _, rr := range records {
+				if rr.Header().Name == fqdn && rr.Header().Rrtype == rrType {
+					matching = append(matching, rr)
+				}
+			}
+			return matching, nil
+		}
+
+		msg := new(dns.Msg)
+		msg.SetQuestion(fqdn, rrType)
 
 		// Set recursion desired flag
 		msg.RecursionDesired = dnsClient.recursive

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -77,6 +77,11 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 							Optional:    true,
 							Description: "Enable the Recursion Desired (RD) flag on DNS queries",
 						},
+						"use_axfr": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Use AXFR (zone transfer) to read DNS records instead of individual queries. " +
+								"Useful for large zones where querying each record individually is slow.",
+						},
 						"key_name": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
@@ -174,7 +179,7 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	var server, transport, timeout, keyname, keyalgo, keysecret, realm, username, password, keytab string
 	var port, retries int
 	var duration time.Duration
-	var gssapi, recursive bool
+	var gssapi, recursive, useAxfr bool
 	var configErr error
 
 	providerUpdateConfig := make([]providerUpdateModel, 1)
@@ -201,6 +206,7 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	keyalgo = providerUpdateConfig[0].KeyAlgorithm.ValueString()
 	keysecret = providerUpdateConfig[0].KeySecret.ValueString()
 	recursive = providerUpdateConfig[0].Recursive.ValueBool()
+	useAxfr = providerUpdateConfig[0].UseAxfr.ValueBool()
 
 	if providerUpdateConfig[0].Server.IsNull() && len(os.Getenv("DNS_UPDATE_SERVER")) > 0 {
 		server = os.Getenv("DNS_UPDATE_SERVER")
@@ -345,6 +351,7 @@ func (p *dnsProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		username:  username,
 		password:  password,
 		keytab:    keytab,
+		useAxfr:   useAxfr,
 	}
 
 	resp.ResourceData, configErr = config.Client(ctx)
@@ -388,6 +395,7 @@ type providerUpdateModel struct {
 	Timeout      types.String `tfsdk:"timeout"`
 	Retries      types.Int64  `tfsdk:"retries"`
 	Recursive    types.Bool   `tfsdk:"recursive"`
+	UseAxfr      types.Bool   `tfsdk:"use_axfr"`
 	KeyName      types.String `tfsdk:"key_name"`
 	KeyAlgorithm types.String `tfsdk:"key_algorithm"`
 	KeySecret    types.String `tfsdk:"key_secret"`
@@ -412,6 +420,7 @@ func (m providerUpdateModel) objectAttributeTypes() map[string]attr.Type {
 		"timeout":       types.StringType,
 		"transport":     types.StringType,
 		"recursive":     types.BoolType,
+		"use_axfr":      types.BoolType,
 	}
 }
 
@@ -522,6 +531,22 @@ func resourceFQDN_framework(config dnsConfig) string {
 func resourceDnsRead_framework(config dnsConfig, client *DNSClient, rrType uint16) ([]dns.RR, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	fqdn := resourceFQDN_framework(config)
+
+	if client.useAxfr {
+		records, err := axfrQuery(client, config.Zone)
+		if err != nil {
+			diags.AddError("Error reading DNS records via AXFR:", err.Error())
+			return nil, diags
+		}
+
+		var matching []dns.RR
+		for _, rr := range records {
+			if rr.Header().Name == fqdn && rr.Header().Rrtype == rrType {
+				matching = append(matching, rr)
+			}
+		}
+		return matching, nil
+	}
 
 	msg := new(dns.Msg)
 	msg.SetQuestion(fqdn, rrType)


### PR DESCRIPTION
## Description

Adds a `use_axfr` option to the provider configuration that enables zone transfer (AXFR) for reading DNS records instead of individual queries. This is especially useful for large zones where querying each record individually is slow.

### Changes:
- Created `internal/provider/axfr.go` with `axfrQuery` function implementing AXFR zone transfer
- Added `useAxfr` field to `Config` and `DNSClient` structs
- Added `use_axfr` boolean to provider schema (both SDK v2 and framework providers)
- Modified `resourceDnsRead` and `resourceDnsRead_framework` to use AXFR when enabled, filtering results by FQDN and record type
- Supports both TSIG and GSS-TSIG authentication via `TsigProvider`

### Usage:
```hcl
provider dns {
  update {
    server = ns.example.com
    use_axfr = true
  }
}
```

Closes #360