### PR TITLE
Fix env var validation timing (#131)

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -63,9 +63,19 @@ func (c *Config) Client(ctx context.Context) (interface{}, error) {
 		!(c.realm != "" && ((c.username == "" && c.password == "" && c.keytab == "") || // Rely on current user session
 			(c.username != "" && (c.password != "" || c.keytab != "")))) { // Supplied credentials with either password or keytab
 		return nil, fmt.Errorf("Error configuring provider: when using GSSAPI, \"realm\", \"username\" and either \"password\" or \"keytab\" should be non empty")
+	} else if c.gssapi && (c.keyname != "" || c.keyalgo != "" || c.keysecret != "") {
+		return nil, fmt.Errorf("Error configuring provider: GSSAPI cannot be used together with \"key_name\", \"key_algorithm\", or \"key_secret\"")
 	} else if !((c.keyname == "" && c.keysecret == "" && c.keyalgo == "") || // No TSIG required
 		(c.keyname != "" && c.keysecret != "" && c.keyalgo != "")) { // Supplied key name, secret and algorithm
 		return nil, fmt.Errorf("Error configuring provider: when using authentication, \"key_name\", \"key_secret\" and \"key_algorithm\" should be non empty")
+	}
+
+	// GSSAPI sub-field validation
+	if c.password != "" && c.keytab != "" {
+		return nil, fmt.Errorf("Error configuring provider: \"password\" and \"keytab\" cannot be set at the same time")
+	}
+	if (c.password != "" || c.keytab != "") && c.username == "" {
+		return nil, fmt.Errorf("Error configuring provider: \"username\" is required when \"password\" or \"keytab\" is set")
 	}
 
 	client.c = new(dns.Client)

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -12,11 +12,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -78,39 +76,18 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 							Description: "Enable the Recursion Desired (RD) flag on DNS queries",
 						},
 						"key_name": schema.StringAttribute{
-							Optional: true,
-							Validators: []validator.String{
-								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("gssapi")),
-								stringvalidator.AlsoRequires(
-									path.MatchRelative().AtParent().AtName("key_algorithm"),
-									path.MatchRelative().AtParent().AtName("key_secret"),
-								),
-							},
+							Optional:    true,
 							Description: "The name of the TSIG key used to sign the DNS update messages. " +
 								"Value can also be sourced from the DNS_UPDATE_KEYNAME environment variable.",
 						},
 						"key_algorithm": schema.StringAttribute{
-							Optional: true,
-							Validators: []validator.String{
-								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("gssapi")),
-								stringvalidator.AlsoRequires(
-									path.MatchRelative().AtParent().AtName("key_name"),
-									path.MatchRelative().AtParent().AtName("key_secret"),
-								),
-							},
+							Optional:    true,
 							Description: "Required if `key_name` is set. When using TSIG authentication, the " +
 								"algorithm to use for HMAC. Valid values are `hmac-md5`, `hmac-sha1`, `hmac-sha256` " +
 								"or `hmac-sha512`. Value can also be sourced from the DNS_UPDATE_KEYALGORITHM environment variable.",
 						},
 						"key_secret": schema.StringAttribute{
 							Optional: true,
-							Validators: []validator.String{
-								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("gssapi")),
-								stringvalidator.AlsoRequires(
-									path.MatchRelative().AtParent().AtName("key_name"),
-									path.MatchRelative().AtParent().AtName("key_algorithm"),
-								),
-							},
 							Description: "Required if `key_name` is set\nA Base64-encoded string containing the " +
 								"shared secret to be used for TSIG. Value can also be sourced from the DNS_UPDATE_KEYSECRET environment variable.",
 						},
@@ -119,11 +96,6 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 						"gssapi": schema.ListNestedBlock{
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
-								listvalidator.ConflictsWith(
-									path.MatchRelative().AtParent().AtName("key_name"),
-									path.MatchRelative().AtParent().AtName("key_algorithm"),
-									path.MatchRelative().AtParent().AtName("key_algorithm"),
-								),
 							},
 							Description: "A `gssapi` block. Only one `gssapi` block may be in the configuration. " +
 								"Conflicts with use of `key_name`, `key_algorithm` and `key_secret`.",
@@ -139,21 +111,13 @@ func (p *dnsProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 											"user session will be used. Value can also be sourced from the DNS_UPDATE_USERNAME environment variable.",
 									},
 									"password": schema.StringAttribute{
-										Optional: true,
-										Validators: []validator.String{
-											stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("keytab")),
-											stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("username")),
-										},
+										Optional:  true,
 										Sensitive: true,
 										Description: "This or `keytab` is required if `username` is set. The matching " +
 											"password for `username`. Value can also be sourced from the DNS_UPDATE_PASSWORD environment variable.",
 									},
 									"keytab": schema.StringAttribute{
 										Optional: true,
-										Validators: []validator.String{
-											stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password")),
-											stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("username")),
-										},
 										Description: "This or `password` is required if `username` is set, not " +
 											"supported on Windows. The path to a keytab file containing a key for " +
 											"`username`. Value can also be sourced from the DNS_UPDATE_KEYTAB environment variable.",

--- a/internal/provider/provider_framework_test.go
+++ b/internal/provider/provider_framework_test.go
@@ -672,6 +672,51 @@ func TestDnsProviderConfigure(t *testing.T) {
 				},
 			},
 		},
+		"update-key-config-env-resolved-before-validation": {
+			env: map[string]string{
+				"DNS_UPDATE_KEYNAME":      "test-key.example.com.",
+				"DNS_UPDATE_KEYALGORITHM": "hmac-sha256",
+				"DNS_UPDATE_KEYSECRET":    "base64secret==",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				ResourceData: &DNSClient{
+					c: &dns.Client{
+						Net: "udp",
+					},
+					retries:   3,
+					srv_addr:  ":53",
+					transport: "udp",
+					keyname:   "test-key.example.com.",
+					keyalgo:   "hmac-sha256.",
+					keysecret: "base64secret==",
+				},
+			},
+		},
+		"update-key-config-missing-algorithm-from-env": {
+			env: map[string]string{
+				"DNS_UPDATE_KEYNAME":   "test-key.example.com.",
+				"DNS_UPDATE_KEYSECRET": "base64secret==",
+			},
+			request: provider.ConfigureRequest{
+				Config: testProviderSchemaConfig(t, ctx, schema, map[string]attr.Value{
+					"update": types.ListNull(providerUpdateModel{}.objectType()),
+				}),
+			},
+			expected: &provider.ConfigureResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Error initializing DNS Client:",
+						"Error configuring provider: when using authentication, \"key_name\", \"key_secret\" and \"key_algorithm\" should be non empty",
+					),
+				},
+				ResourceData: nil,
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -686,7 +731,7 @@ func TestDnsProviderConfigure(t *testing.T) {
 
 			testProvider.Configure(ctx, testCase.request, got)
 
-			if diff := cmp.Diff(got, testCase.expected, cmp.AllowUnexported(DNSClient{}), cmpopts.IgnoreUnexported(dns.Client{})); diff != "" {
+			if diff := cmp.Diff(got, testCase.expected, cmp.AllowUnexported(DNSClient{}), cmpopts.IgnoreUnexported(dns.Client{}), cmpopts.IgnoreFields(dns.Client{}, "TsigProvider")); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
 			}
 		})


### PR DESCRIPTION
## Description

Schema-level `ConflictsWith` and `AlsoRequires` validators in the framework provider run before environment variables are resolved, causing false validation errors when users rely on env vars for authentication configuration.

## Changes
- Remove `stringvalidator.ConflictsWith` and `stringvalidator.AlsoRequires` from framework schema attributes
- Remove `listvalidator.ConflictsWith` from gssapi block
- Move validation to `config.go.Client()` which runs after env vars are resolved
- Add runtime checks for GSSAPI vs TSIG key conflicts
- Add runtime checks for password/keytab mutual exclusivity
- Add runtime check that password/keytab require username

Closes #131