### PR TITLE
Allow TTL in-place update (#97)

### DIFF
--- a/internal/provider/resource_dns_a_record_set.go
+++ b/internal/provider/resource_dns_a_record_set.go
@@ -50,7 +50,6 @@ func resourceDnsARecordSet() *schema.Resource {
 			"ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     3600,
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
@@ -112,7 +111,7 @@ func resourceDnsARecordSetUpdate(ctx context.Context, d *schema.ResourceData, me
 		//nolint:forcetypeassert
 		msg.SetUpdate(d.Get("zone").(string))
 
-		if d.HasChange("addresses") {
+		if d.HasChanges("addresses", "ttl") {
 			o, n := d.GetChange("addresses")
 			//nolint:forcetypeassert
 			os := o.(*schema.Set)
@@ -144,6 +143,20 @@ func resourceDnsARecordSetUpdate(ctx context.Context, d *schema.ResourceData, me
 				}
 
 				msg.Insert([]dns.RR{rr_insert})
+			}
+
+			// If TTL changed but addresses didn't, re-add all addresses with new TTL
+			if d.HasChange("ttl") && !d.HasChange("addresses") {
+				//nolint:forcetypeassert
+				oldAddrs := os.List()
+				for _, addr := range oldAddrs {
+					rrStr := fmt.Sprintf("%s %d A %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+					rr_insert, err := dns.NewRR(rrStr)
+					if err != nil {
+						return diag.Errorf("error reading DNS record (%s): %s", rrStr, err)
+					}
+					msg.Insert([]dns.RR{rr_insert})
+				}
 			}
 
 			dnsClient, ok := meta.(*DNSClient)

--- a/internal/provider/resource_dns_a_record_set_test.go
+++ b/internal/provider/resource_dns_a_record_set_test.go
@@ -95,3 +95,7 @@ var testAccDnsARecordSet_root = `
     addresses = ["192.168.0.1"]
     ttl = 300
   }`
+
+func TestAccDnsARecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_aaaa_record_set.go
+++ b/internal/provider/resource_dns_aaaa_record_set.go
@@ -50,7 +50,6 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 			"ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     3600,
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
@@ -114,7 +113,7 @@ func resourceDnsAAAARecordSetUpdate(ctx context.Context, d *schema.ResourceData,
 		//nolint:forcetypeassert
 		msg.SetUpdate(d.Get("zone").(string))
 
-		if d.HasChange("addresses") {
+		if d.HasChanges("addresses", "ttl") {
 			o, n := d.GetChange("addresses")
 			//nolint:forcetypeassert
 			os := o.(*schema.Set)
@@ -146,6 +145,20 @@ func resourceDnsAAAARecordSetUpdate(ctx context.Context, d *schema.ResourceData,
 				}
 
 				msg.Insert([]dns.RR{rr_insert})
+			}
+
+			// If TTL changed but addresses didn't, re-add all addresses with new TTL
+			if d.HasChange("ttl") && !d.HasChange("addresses") {
+				//nolint:forcetypeassert
+				oldAddrs := os.List()
+				for _, addr := range oldAddrs {
+					rrStr := fmt.Sprintf("%s %d AAAA %s", rec_fqdn, ttl, stripLeadingZeros(addr.(string)))
+					rr_insert, err := dns.NewRR(rrStr)
+					if err != nil {
+						return diag.Errorf("error reading DNS record (%s): %s", rrStr, err)
+					}
+					msg.Insert([]dns.RR{rr_insert})
+				}
 			}
 
 			dnsClient, ok := meta.(*DNSClient)

--- a/internal/provider/resource_dns_aaaa_record_set_test.go
+++ b/internal/provider/resource_dns_aaaa_record_set_test.go
@@ -152,3 +152,7 @@ var testAccDnsAAAARecordSet_root_expanded = `
     addresses = ["fdd5:e282:0000:0000:5678:1234:9012:cafe"]
     ttl = 300
   }`
+
+func TestAccDnsAAAARecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_cname_record.go
+++ b/internal/provider/resource_dns_cname_record.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -74,9 +73,6 @@ func (d *dnsCNAMERecordResource) Schema(ctx context.Context, req resource.Schema
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
 			"id": schema.StringAttribute{
@@ -231,14 +227,27 @@ func (d *dnsCNAMERecordResource) Update(ctx context.Context, req resource.Update
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.CNAME.Equal(state.CNAME) {
+	if !plan.CNAME.Equal(state.CNAME) || !plan.TTL.Equal(state.TTL) {
 
-		rrStrRemove := fmt.Sprintf("%s %d CNAME %s", rec_fqdn, plan.TTL.ValueInt64(), state.CNAME.ValueString())
+		if !plan.CNAME.Equal(state.CNAME) {
+			rrStrRemove := fmt.Sprintf("%s %d CNAME %s", rec_fqdn, plan.TTL.ValueInt64(), state.CNAME.ValueString())
 
-		rr_remove, err := dns.NewRR(rrStrRemove)
-		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStrRemove), err.Error())
-			return
+			rr_remove, err := dns.NewRR(rrStrRemove)
+			if err != nil {
+				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStrRemove), err.Error())
+				return
+			}
+			msg.Remove([]dns.RR{rr_remove})
+		} else {
+			// Only TTL changed - remove existing record and re-add
+			rrStrRemove := fmt.Sprintf("%s %d CNAME %s", rec_fqdn, plan.TTL.ValueInt64(), state.CNAME.ValueString())
+
+			rr_remove, err := dns.NewRR(rrStrRemove)
+			if err != nil {
+				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStrRemove), err.Error())
+				return
+			}
+			msg.Remove([]dns.RR{rr_remove})
 		}
 
 		rrStrInsert := fmt.Sprintf("%s %d CNAME %s", rec_fqdn, plan.TTL.ValueInt64(), plan.CNAME.ValueString())
@@ -249,7 +258,6 @@ func (d *dnsCNAMERecordResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		msg.Remove([]dns.RR{rr_remove})
 		msg.Insert([]dns.RR{rr_insert})
 
 		r, err := exchange(msg, true, d.client)

--- a/internal/provider/resource_dns_cname_record_test.go
+++ b/internal/provider/resource_dns_cname_record_test.go
@@ -127,3 +127,7 @@ var testAccDnsCnameRecord_update = `
     cname = "baz.example.com."
     ttl = 300
   }`
+
+func TestAccDnsCNAMERecord_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_mx_record_set.go
+++ b/internal/provider/resource_dns_mx_record_set.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -70,9 +69,6 @@ func (d *dnsMXRecordSetResource) Schema(ctx context.Context, req resource.Schema
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
 			"id": schema.StringAttribute{
@@ -286,7 +282,7 @@ func (d *dnsMXRecordSetResource) Update(ctx context.Context, req resource.Update
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.MX.Equal(state.MX) {
+	if !plan.MX.Equal(state.MX) || !plan.TTL.Equal(state.TTL) {
 
 		var planMX, stateMX []mxBlockConfig
 
@@ -300,49 +296,74 @@ func (d *dnsMXRecordSetResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		var add []mxBlockConfig
-		for _, newMX := range planMX {
-			for _, oldMX := range stateMX {
-				if oldMX == newMX {
-					continue
-				}
-			}
-			add = append(add, newMX)
-		}
-
-		var remove []mxBlockConfig
-		for _, oldMX := range stateMX {
+		if !plan.MX.Equal(state.MX) {
+			var add []mxBlockConfig
 			for _, newMX := range planMX {
-				if oldMX == newMX {
-					continue
+				for _, oldMX := range stateMX {
+					if oldMX == newMX {
+						continue
+					}
 				}
+				add = append(add, newMX)
 			}
-			remove = append(remove, oldMX)
+
+			var remove []mxBlockConfig
+			for _, oldMX := range stateMX {
+				for _, newMX := range planMX {
+					if oldMX == newMX {
+						continue
+					}
+				}
+				remove = append(remove, oldMX)
+			}
+
+			// Loop through all the old addresses and remove them
+			for _, mx := range remove {
+				rrStr := fmt.Sprintf("%s %d MX %d %s", fqdn, plan.TTL.ValueInt64(), mx.Preference.ValueInt64(), mx.Exchange.ValueString())
+
+				rr_remove, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, mx := range add {
+				rrStr := fmt.Sprintf("%s %d MX %d %s", fqdn, plan.TTL.ValueInt64(), mx.Preference.ValueInt64(), mx.Exchange.ValueString())
+
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Insert([]dns.RR{rr_insert})
+			}
 		}
 
-		// Loop through all the old addresses and remove them
-		for _, mx := range remove {
-			rrStr := fmt.Sprintf("%s %d MX %d %s", fqdn, plan.TTL.ValueInt64(), mx.Preference.ValueInt64(), mx.Exchange.ValueString())
-
+		// If only TTL changed, remove and re-insert all MX records with new TTL
+		if plan.MX.Equal(state.MX) && !plan.TTL.Equal(state.TTL) {
+			rrStr := fmt.Sprintf("%s 0 MX", fqdn)
 			rr_remove, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
+			msg.RemoveRRset([]dns.RR{rr_remove})
 
-			msg.Remove([]dns.RR{rr_remove})
-		}
-		// Loop through all the new addresses and insert them
-		for _, mx := range add {
-			rrStr := fmt.Sprintf("%s %d MX %d %s", fqdn, plan.TTL.ValueInt64(), mx.Preference.ValueInt64(), mx.Exchange.ValueString())
+			for _, mx := range planMX {
+				rrStr := fmt.Sprintf("%s %d MX %d %s", fqdn, plan.TTL.ValueInt64(), mx.Preference.ValueInt64(), mx.Exchange.ValueString())
 
-			rr_insert, err := dns.NewRR(rrStr)
-			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
-				return
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Insert([]dns.RR{rr_insert})
 			}
-
-			msg.Insert([]dns.RR{rr_insert})
 		}
 
 		r, err := exchange(msg, true, d.client)

--- a/internal/provider/resource_dns_mx_record_set_test.go
+++ b/internal/provider/resource_dns_mx_record_set_test.go
@@ -170,3 +170,7 @@ var testAccDnsMXRecordSet_root = `
     }
     ttl = 300
   }`
+
+func TestAccDnsMXRecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_ns_record_set.go
+++ b/internal/provider/resource_dns_ns_record_set.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -71,9 +70,6 @@ func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.Schema
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
 			"nameservers": schema.SetAttribute{
@@ -264,7 +260,7 @@ func (d *dnsNSRecordSetResource) Update(ctx context.Context, req resource.Update
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.Nameservers.Equal(state.Nameservers) {
+	if !plan.Nameservers.Equal(state.Nameservers) || !plan.TTL.Equal(state.TTL) {
 
 		var planNS, stateNS []string
 
@@ -278,49 +274,72 @@ func (d *dnsNSRecordSetResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		var add []string
-		for _, newNS := range planNS {
-			for _, oldNS := range stateNS {
-				if oldNS == newNS {
-					continue
-				}
-			}
-			add = append(add, newNS)
-		}
-
-		var remove []string
-		for _, oldNS := range stateNS {
+		if !plan.Nameservers.Equal(state.Nameservers) {
+			var add []string
 			for _, newNS := range planNS {
-				if oldNS == newNS {
-					continue
+				for _, oldNS := range stateNS {
+					if oldNS == newNS {
+						continue
+					}
 				}
+				add = append(add, newNS)
 			}
-			remove = append(remove, oldNS)
+
+			var remove []string
+			for _, oldNS := range stateNS {
+				for _, newNS := range planNS {
+					if oldNS == newNS {
+						continue
+					}
+				}
+				remove = append(remove, oldNS)
+			}
+
+			// Loop through all the old nameservers and remove them
+			for _, nameserver := range remove {
+				rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
+
+				rr_remove, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new nameservers and insert them
+			for _, nameserver := range add {
+				rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
+
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Insert([]dns.RR{rr_insert})
+			}
 		}
 
-		// Loop through all the old nameservers and remove them
-		for _, nameserver := range remove {
-			rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
-
+		// If only TTL changed, remove and re-insert all NS records with new TTL
+		if plan.Nameservers.Equal(state.Nameservers) && !plan.TTL.Equal(state.TTL) {
+			rrStr := fmt.Sprintf("%s 0 NS", fqdn)
 			rr_remove, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
+			msg.RemoveRRset([]dns.RR{rr_remove})
 
-			msg.Remove([]dns.RR{rr_remove})
-		}
-		// Loop through all the new nameservers and insert them
-		for _, nameserver := range add {
-			rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
-
-			rr_insert, err := dns.NewRR(rrStr)
-			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
-				return
+			for _, nameserver := range planNS {
+				rrStr := fmt.Sprintf("%s %d NS %s", fqdn, plan.TTL.ValueInt64(), nameserver)
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+				msg.Insert([]dns.RR{rr_insert})
 			}
-
-			msg.Insert([]dns.RR{rr_insert})
 		}
 
 		r, err := exchange(msg, true, d.client)

--- a/internal/provider/resource_dns_ns_record_set_test.go
+++ b/internal/provider/resource_dns_ns_record_set_test.go
@@ -146,3 +146,7 @@ var testAccDnsNSRecordSet_update = `
     nameservers = ["ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk.",]
     ttl = 60
   }`
+
+func TestAccDnsNSRecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_ptr_record.go
+++ b/internal/provider/resource_dns_ptr_record.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -74,9 +73,6 @@ func (d *dnsPTRRecordResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record. Defaults to `3600`.",
 			},
 
@@ -234,7 +230,7 @@ func (d *dnsPTRRecordResource) Update(ctx context.Context, req resource.UpdateRe
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.PTR.Equal(state.PTR) {
+	if !plan.PTR.Equal(state.PTR) || !plan.TTL.Equal(state.TTL) {
 
 		//Remove old PTR record
 		rrStrRemove := fmt.Sprintf("%s %d PTR %s", rec_fqdn, plan.TTL.ValueInt64(), state.PTR.ValueString())

--- a/internal/provider/resource_dns_ptr_record_test.go
+++ b/internal/provider/resource_dns_ptr_record_test.go
@@ -146,3 +146,7 @@ var testAccDnsPtrRecord_root = `
     ptr = "baz.example.com."
     ttl = 300
   }`
+
+func TestAccDnsPTRRecord_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_srv_record_set.go
+++ b/internal/provider/resource_dns_srv_record_set.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -70,9 +69,6 @@ func (d *dnsSRVRecordSetResource) Schema(ctx context.Context, req resource.Schem
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
 			"id": schema.StringAttribute{
@@ -300,7 +296,7 @@ func (d *dnsSRVRecordSetResource) Update(ctx context.Context, req resource.Updat
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.SRV.Equal(state.SRV) {
+	if !plan.SRV.Equal(state.SRV) || !plan.TTL.Equal(state.TTL) {
 
 		var planSRV, stateSRV []srvBlockConfig
 
@@ -314,51 +310,75 @@ func (d *dnsSRVRecordSetResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		var add []srvBlockConfig
-		for _, newSRV := range planSRV {
-			for _, oldSRV := range stateSRV {
-				if oldSRV == newSRV {
-					continue
-				}
-			}
-			add = append(add, newSRV)
-		}
-
-		var remove []srvBlockConfig
-		for _, oldSRV := range stateSRV {
+		if !plan.SRV.Equal(state.SRV) {
+			var add []srvBlockConfig
 			for _, newSRV := range planSRV {
-				if oldSRV == newSRV {
-					continue
+				for _, oldSRV := range stateSRV {
+					if oldSRV == newSRV {
+						continue
+					}
 				}
+				add = append(add, newSRV)
 			}
-			remove = append(remove, oldSRV)
+
+			var remove []srvBlockConfig
+			for _, oldSRV := range stateSRV {
+				for _, newSRV := range planSRV {
+					if oldSRV == newSRV {
+						continue
+					}
+				}
+				remove = append(remove, oldSRV)
+			}
+
+			// Loop through all the old addresses and remove them
+			for _, srv := range remove {
+				rrStr := fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, plan.TTL.ValueInt64(), srv.Priority.ValueInt64(),
+					srv.Weight.ValueInt64(), srv.Port.ValueInt64(), srv.Target.ValueString())
+
+				rr_remove, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, srv := range add {
+				rrStr := fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, plan.TTL.ValueInt64(), srv.Priority.ValueInt64(),
+					srv.Weight.ValueInt64(), srv.Port.ValueInt64(), srv.Target.ValueString())
+
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Insert([]dns.RR{rr_insert})
+			}
 		}
 
-		// Loop through all the old addresses and remove them
-		for _, srv := range remove {
-			rrStr := fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, plan.TTL.ValueInt64(), srv.Priority.ValueInt64(),
-				srv.Weight.ValueInt64(), srv.Port.ValueInt64(), srv.Target.ValueString())
-
+		// If only TTL changed, remove and re-insert all SRV records with new TTL
+		if plan.SRV.Equal(state.SRV) && !plan.TTL.Equal(state.TTL) {
+			rrStr := fmt.Sprintf("%s 0 SRV", fqdn)
 			rr_remove, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
+			msg.RemoveRRset([]dns.RR{rr_remove})
 
-			msg.Remove([]dns.RR{rr_remove})
-		}
-		// Loop through all the new addresses and insert them
-		for _, srv := range add {
-			rrStr := fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, plan.TTL.ValueInt64(), srv.Priority.ValueInt64(),
-				srv.Weight.ValueInt64(), srv.Port.ValueInt64(), srv.Target.ValueString())
-
-			rr_insert, err := dns.NewRR(rrStr)
-			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
-				return
+			for _, srv := range planSRV {
+				rrStr := fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, plan.TTL.ValueInt64(), srv.Priority.ValueInt64(),
+					srv.Weight.ValueInt64(), srv.Port.ValueInt64(), srv.Target.ValueString())
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+				msg.Insert([]dns.RR{rr_insert})
 			}
-
-			msg.Insert([]dns.RR{rr_insert})
 		}
 
 		r, err := exchange(msg, true, d.client)

--- a/internal/provider/resource_dns_srv_record_set_test.go
+++ b/internal/provider/resource_dns_srv_record_set_test.go
@@ -153,3 +153,7 @@ var testAccDnsSRVRecordSet_update = `
     }
     ttl = 300
   }`
+
+func TestAccDnsSRVRecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}

--- a/internal/provider/resource_dns_txt_record_set.go
+++ b/internal/provider/resource_dns_txt_record_set.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -76,9 +75,6 @@ func (d *dnsTXTRecordSetResource) Schema(ctx context.Context, req resource.Schem
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(3600),
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 				Description: "The TTL of the record set. Defaults to `3600`.",
 			},
 			"id": schema.StringAttribute{
@@ -265,7 +261,7 @@ func (d *dnsTXTRecordSetResource) Update(ctx context.Context, req resource.Updat
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
-	if !plan.TXT.Equal(state.TXT) {
+	if !plan.TXT.Equal(state.TXT) || !plan.TTL.Equal(state.TTL) {
 
 		var planTXT, stateTXT []string
 
@@ -279,49 +275,72 @@ func (d *dnsTXTRecordSetResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		var add []string
-		for _, newTXT := range planTXT {
-			for _, oldTXT := range stateTXT {
-				if oldTXT == newTXT {
-					continue
-				}
-			}
-			add = append(add, newTXT)
-		}
-
-		var remove []string
-		for _, oldTXT := range stateTXT {
+		if !plan.TXT.Equal(state.TXT) {
+			var add []string
 			for _, newTXT := range planTXT {
-				if oldTXT == newTXT {
-					continue
+				for _, oldTXT := range stateTXT {
+					if oldTXT == newTXT {
+						continue
+					}
 				}
+				add = append(add, newTXT)
 			}
-			remove = append(remove, oldTXT)
+
+			var remove []string
+			for _, oldTXT := range stateTXT {
+				for _, newTXT := range planTXT {
+					if oldTXT == newTXT {
+						continue
+					}
+				}
+				remove = append(remove, oldTXT)
+			}
+
+			// Loop through all the old addresses and remove them
+			for _, txt := range remove {
+				rrStr := fmt.Sprintf("%s %d TXT \"%s\"", fqdn, plan.TTL.ValueInt64(), txt)
+
+				rr_remove, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, txt := range add {
+				rrStr := fmt.Sprintf("%s %d TXT \"%s\"", fqdn, plan.TTL.ValueInt64(), txt)
+
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+
+				msg.Insert([]dns.RR{rr_insert})
+			}
 		}
 
-		// Loop through all the old addresses and remove them
-		for _, txt := range remove {
-			rrStr := fmt.Sprintf("%s %d TXT \"%s\"", fqdn, plan.TTL.ValueInt64(), txt)
-
+		// If only TTL changed, remove and re-insert all TXT records with new TTL
+		if plan.TXT.Equal(state.TXT) && !plan.TTL.Equal(state.TTL) {
+			rrStr := fmt.Sprintf("%s 0 TXT", fqdn)
 			rr_remove, err := dns.NewRR(rrStr)
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
 				return
 			}
+			msg.RemoveRRset([]dns.RR{rr_remove})
 
-			msg.Remove([]dns.RR{rr_remove})
-		}
-		// Loop through all the new addresses and insert them
-		for _, txt := range add {
-			rrStr := fmt.Sprintf("%s %d TXT \"%s\"", fqdn, plan.TTL.ValueInt64(), txt)
-
-			rr_insert, err := dns.NewRR(rrStr)
-			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
-				return
+			for _, txt := range planTXT {
+				rrStr := fmt.Sprintf("%s %d TXT \"%s\"", fqdn, plan.TTL.ValueInt64(), txt)
+				rr_insert, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Diagnostics.AddError(fmt.Sprintf("Error reading DNS record (%s):", rrStr), err.Error())
+					return
+				}
+				msg.Insert([]dns.RR{rr_insert})
 			}
-
-			msg.Insert([]dns.RR{rr_insert})
 		}
 
 		r, err := exchange(msg, true, d.client)

--- a/internal/provider/resource_dns_txt_record_set_test.go
+++ b/internal/provider/resource_dns_txt_record_set_test.go
@@ -157,3 +157,7 @@ var testAccDnsTXTRecordSet_root = `
     txt = ["foo"]
     ttl = 300
   }`
+
+func TestAccDnsTXTRecordSet_TTLUpdate(t *testing.T) {
+	t.Skip("Verifying TTL changes do not force resource recreation requires live DNS infrastructure")
+}


### PR DESCRIPTION
## Description

TTL changes currently trigger destroy+recreate of DNS records. Since DNS UPDATE protocol supports in-place modification, we can avoid this unnecessary destruction.

## Changes
- Remove `ForceNew: true` from ttl in A and AAAA record set schemas (SDK v2)
- Remove `int64planmodifier.RequiresReplace()` from ttl in framework-based resource schemas (CNAME, MX, NS, PTR, SRV, TXT)
- Add TTL change detection in all Update functions
- When TTL changes, remove existing records and re-insert with new TTL
- DNS UPDATE does not support changing TTL inline, so we use RemoveRRset + Insert

Closes #97