### PR TITLE
Add zone prerequisite for NS record updates on Windows AD DNS (#318)

### DIFF
--- a/internal/provider/resource_dns_ns_record_set.go
+++ b/internal/provider/resource_dns_ns_record_set.go
@@ -129,6 +129,24 @@ func (d *dnsNSRecordSetResource) Create(ctx context.Context, req resource.Create
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
 
+	// Windows AD requires a zone authority (SOA) prerequisite for NS delegation updates
+	zone := dns.Fqdn(plan.Zone.ValueString())
+	msg.Answer = append(msg.Answer, &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassANY,
+			Ttl:    0,
+		},
+		Ns:      zone,
+		Mbox:    zone,
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   900,
+		Expire:  86400,
+		Minttl:  3600,
+	})
+
 	var planNS []string
 
 	resp.Diagnostics.Append(plan.Nameservers.ElementsAs(ctx, &planNS, false)...)
@@ -263,6 +281,24 @@ func (d *dnsNSRecordSetResource) Update(ctx context.Context, req resource.Update
 
 	msg := new(dns.Msg)
 	msg.SetUpdate(plan.Zone.ValueString())
+
+	// Windows AD requires a zone authority (SOA) prerequisite for NS delegation updates
+	zone := dns.Fqdn(plan.Zone.ValueString())
+	msg.Answer = append(msg.Answer, &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassANY,
+			Ttl:    0,
+		},
+		Ns:      zone,
+		Mbox:    zone,
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   900,
+		Expire:  86400,
+		Minttl:  3600,
+	})
 
 	if !plan.Nameservers.Equal(state.Nameservers) {
 

--- a/internal/provider/resource_dns_ns_record_set_test.go
+++ b/internal/provider/resource_dns_ns_record_set_test.go
@@ -146,3 +146,7 @@ var testAccDnsNSRecordSet_update = `
     nameservers = ["ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk.",]
     ttl = 60
   }`
+
+func TestAccDnsNSRecordSet_WindowsADPrerequisite(t *testing.T) {
+	t.Skip("NS prerequisite changes require Windows AD DNS infrastructure; cannot unit test")
+}


### PR DESCRIPTION
Fixes #318

Windows AD DNS requires a zone authority (SOA) prerequisite when accepting NS delegation updates via dynamic DNS. Without this prerequisite, the server returns RCODE 5 (REFUSED).

This change adds a prerequisite in both Create and Update methods of the NS record set resource, ensuring the zone SOA exists before attempting NS record operations.