### PR TITLE
Document wildcard record limitation on Windows DNS (#245)

### DIFF
--- a/docs/resources/a_record_set.md
+++ b/docs/resources/a_record_set.md
@@ -35,7 +35,7 @@ resource "dns_a_record_set" "www" {
 
 ### Optional
 
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `ttl` (Number) The TTL of the record set. Defaults to `3600`.
 
 ### Read-Only

--- a/docs/resources/aaaa_record_set.md
+++ b/docs/resources/aaaa_record_set.md
@@ -34,7 +34,7 @@ resource "dns_aaaa_record_set" "www" {
 
 ### Optional
 
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `ttl` (Number) The TTL of the record set. Defaults to `3600`.
 
 ### Read-Only

--- a/docs/resources/cname_record.md
+++ b/docs/resources/cname_record.md
@@ -27,7 +27,7 @@ resource "dns_cname_record" "foo" {
 ### Required
 
 - `cname` (String) The canonical name this record will point to.
-- `name` (String) The name of the record. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `zone` (String) DNS zone the record belongs to. It must be an FQDN, that is, include the trailing dot.
 
 ### Optional

--- a/docs/resources/mx_record_set.md
+++ b/docs/resources/mx_record_set.md
@@ -64,7 +64,7 @@ resource "dns_mx_record_set" "mx" {
 ### Optional
 
 - `mx` (Block Set) Can be specified multiple times for each MX record. (see [below for nested schema](#nestedblock--mx))
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `ttl` (Number) The TTL of the record set. Defaults to `3600`.
 
 ### Read-Only

--- a/docs/resources/ns_record_set.md
+++ b/docs/resources/ns_record_set.md
@@ -29,7 +29,7 @@ resource "dns_ns_record_set" "www" {
 
 ### Required
 
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `nameservers` (Set of String) The nameservers this record set will point to.
 - `zone` (String) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
 

--- a/docs/resources/ptr_record.md
+++ b/docs/resources/ptr_record.md
@@ -31,7 +31,7 @@ resource "dns_ptr_record" "dns-sd" {
 
 ### Optional
 
-- `name` (String) The name of the record. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `ttl` (Number) The TTL of the record. Defaults to `3600`.
 
 ### Read-Only

--- a/docs/resources/srv_record_set.md
+++ b/docs/resources/srv_record_set.md
@@ -43,7 +43,7 @@ resource "dns_srv_record_set" "sip" {
 
 ### Required
 
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `zone` (String) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
 
 ### Optional

--- a/docs/resources/txt_record_set.md
+++ b/docs/resources/txt_record_set.md
@@ -32,7 +32,7 @@ resource "dns_txt_record_set" "google" {
 
 ### Optional
 
-- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+- `name` (String) The name of the record set. The `zone` argument will be appended to this value to create the full record path. Wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates.
 - `ttl` (Number) The TTL of the record set. Defaults to `3600`.
 
 ### Read-Only

--- a/internal/provider/resource_dns_a_record_set.go
+++ b/internal/provider/resource_dns_a_record_set.go
@@ -37,8 +37,9 @@ func resourceDnsARecordSet() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateName,
-				Description: "The name of the record set. The `zone` argument will be appended to this value to " +
-					"create the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to " +
+				"create the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"addresses": {
 				Type:        schema.TypeSet,

--- a/internal/provider/resource_dns_aaaa_record_set.go
+++ b/internal/provider/resource_dns_aaaa_record_set.go
@@ -37,8 +37,9 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateName,
-				Description: "The name of the record set. The `zone` argument will be appended to this value to " +
-					"create the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to " +
+				"create the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"addresses": {
 				Type:        schema.TypeSet,

--- a/internal/provider/resource_dns_cname_record.go
+++ b/internal/provider/resource_dns_cname_record.go
@@ -60,8 +60,9 @@ func (d *dnsCNAMERecordResource) Schema(ctx context.Context, req resource.Schema
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"cname": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_mx_record_set.go
+++ b/internal/provider/resource_dns_mx_record_set.go
@@ -63,8 +63,9 @@ func (d *dnsMXRecordSetResource) Schema(ctx context.Context, req resource.Schema
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"ttl": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/resource_dns_ns_record_set.go
+++ b/internal/provider/resource_dns_ns_record_set.go
@@ -64,8 +64,9 @@ func (d *dnsNSRecordSetResource) Schema(ctx context.Context, req resource.Schema
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"ttl": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/resource_dns_ptr_record.go
+++ b/internal/provider/resource_dns_ptr_record.go
@@ -60,8 +60,9 @@ func (d *dnsPTRRecordResource) Schema(ctx context.Context, req resource.SchemaRe
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"ptr": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resource_dns_srv_record_set.go
+++ b/internal/provider/resource_dns_srv_record_set.go
@@ -63,8 +63,9 @@ func (d *dnsSRVRecordSetResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"ttl": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/resource_dns_txt_record_set.go
+++ b/internal/provider/resource_dns_txt_record_set.go
@@ -64,8 +64,9 @@ func (d *dnsTXTRecordSetResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.String{
 					dnsvalidator.IsRecordNameValid(),
 				},
-				Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
-					"the full record path.",
+			Description: "The name of the record set. The `zone` argument will be appended to this value to create " +
+				"the full record path. Wildcard records (names starting with `*.`) " +
+				"are not supported on Windows DNS servers when using dynamic DNS updates.",
 			},
 			"txt": schema.SetAttribute{
 				Required:    true,


### PR DESCRIPTION
Fixes #245

Adds documentation notes to all resource types explaining that wildcard records (names starting with `*.`) are not supported on Windows DNS servers when using dynamic DNS updates per RFC 2136. This is a Windows DNS server limitation, not a provider bug.